### PR TITLE
feat: implementação backend do caso de uso de cadastro de login supervisor/engenheiro (US_03)

### DIFF
--- a/backend/src/modules/colaborador/api/http/colaborador_routes.py
+++ b/backend/src/modules/colaborador/api/http/colaborador_routes.py
@@ -12,7 +12,7 @@ from src.modules.noticacao.infrastructure.SmtpEmailNotificacao import SmtpEmailN
 from src.shared.auth.dependencies import verify_supervisor_role
 from src.shared.validators.email_validator import EmailValidator
 
-router = APIRouter()
+router = APIRouter(tags=["Colaboradores"])
 
 def get_colaborador_repository(session: Annotated[Session, Depends(get_session)]):
     return ColaboradorRepository(session)
@@ -32,7 +32,13 @@ def get_email_sender():
 def get_email_validator():
     return EmailValidator()
 
-@router.post("/", response_model=ColaboradorResponseDTO, status_code=201)
+@router.post(
+    "/",
+    response_model=ColaboradorResponseDTO,
+    status_code=201,
+    summary="Criar novo Colaborador",
+    description="Cria um novo colaborador vinculado a um supervisor, gerando senha automática e enviando por email"
+)
 async def criar_colaborador(
     create_data: CreateColaboradorDTO,
     _: Annotated[dict, Depends(verify_supervisor_role)],

--- a/backend/src/modules/colaborador/application/dtos/colaborador_dto.py
+++ b/backend/src/modules/colaborador/application/dtos/colaborador_dto.py
@@ -1,8 +1,10 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 from typing import Optional
 from datetime import datetime
 
 class CreateColaboradorDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    
     nome: str
     id_profissional_responsavel: str
     uf: str
@@ -13,8 +15,10 @@ class CreateColaboradorDTO(BaseModel):
 
 
 class ColaboradorResponseDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    
     id: int
-    name: str
+    nome: str
     id_profissional_responsavel: str
     uf: str
     cidade: str

--- a/backend/src/modules/colaborador/application/use_case/uc_04.py
+++ b/backend/src/modules/colaborador/application/use_case/uc_04.py
@@ -83,7 +83,7 @@ class CriarColaboradorUseCase:
             
             return ColaboradorResponseDTO(
                 id=colaborador_salvo.id,
-                name=colaborador_salvo.nome,
+                nome=colaborador_salvo.nome,
                 id_profissional_responsavel=colaborador_salvo.id_profissional_responsavel,
                 uf=colaborador_salvo.uf,
                 cidade=colaborador_salvo.cidade,

--- a/backend/src/modules/supervisor/api/http/supervisor_routes.py
+++ b/backend/src/modules/supervisor/api/http/supervisor_routes.py
@@ -14,7 +14,7 @@ from src.modules.supervisor.infrastructure.security.argon2_hasher import Argon2P
 from src.shared.auth.jwt_service import JWTService
 from src.shared.validators.email_validator import EmailValidator
 
-router = APIRouter()
+router = APIRouter(tags=["Supervisores"])
 
 def get_repository(session: Annotated[Session, Depends(get_session)]):
     return SupervisorRepository(session)
@@ -31,7 +31,13 @@ def get_token_service():
 def get_email_validator():
     return EmailValidator()
 
-@router.post("/", response_model=SupervisorResponseDTO, status_code=201)
+@router.post(
+    "/",
+    response_model=SupervisorResponseDTO,
+    status_code=201,
+    summary="Criar novo Supervisor",
+    description="Cria um novo supervisor após validar CREA, email e outros dados obrigatórios"
+)
 async def criar_supervisor(
     create_data: CreateSupervisorDTO,
     repository = Depends(get_repository),
@@ -47,7 +53,12 @@ async def criar_supervisor(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao criar supervisor: {str(e)}")
 
-@router.get("/", response_model=list[SupervisorResponseDTO])
+@router.get(
+    "/",
+    response_model=list[SupervisorResponseDTO],
+    summary="Listar Supervisores",
+    description="Retorna a lista de todos os supervisores cadastrados no sistema"
+)
 async def listar_supervisores(
     repository = Depends(get_repository)
 ):
@@ -57,7 +68,13 @@ async def listar_supervisores(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao listar supervisores: {str(e)}")
 
-@router.post("/login", response_model=LoginResponseDTO, status_code=200)
+@router.post(
+    "/login",
+    response_model=LoginResponseDTO,
+    status_code=200,
+    summary="Autenticar Supervisor",
+    description="Realiza login do supervisor com validação de credenciais e retorna tokens JWT"
+)
 async def login(
     login_data: LoginDTO,
     repository = Depends(get_repository),

--- a/backend/src/modules/supervisor/application/dtos/supervisor_dto.py
+++ b/backend/src/modules/supervisor/application/dtos/supervisor_dto.py
@@ -1,21 +1,25 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 from typing import Optional
 from datetime import datetime
 
 
 class CreateSupervisorDTO(BaseModel):
-    name: str
-    idendificador_profissional: str
+    model_config = ConfigDict(populate_by_name=True)
+    
+    nome: str
+    identificador_profissional: str
     uf: str
     cidade: str
     email: EmailStr
-    password: str
+    senha: str
 
 
 class SupervisorResponseDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    
     id: int
-    name: str
-    idendificador_profissional: str
+    nome: str
+    identificador_profissional: str
     uf: str
     cidade: str
     email: str

--- a/backend/src/modules/supervisor/application/user_case/ListarSupervisorUseCase.py
+++ b/backend/src/modules/supervisor/application/user_case/ListarSupervisorUseCase.py
@@ -12,9 +12,9 @@ class ListarSupervisorUseCase:
         return [
             SupervisorResponseDTO(
                 id=supervisor.id,
-                name=supervisor.name,
+                nome=supervisor.name,
                 email=supervisor.email,
-                idendificador_profissional=supervisor.idendificador_profissional,
+                identificador_profissional=supervisor.idendificador_profissional,
                 uf=supervisor.uf,
                 cidade=supervisor.cidade
             )

--- a/backend/src/modules/supervisor/application/user_case/uc_01.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_01.py
@@ -23,8 +23,8 @@ class CriarSupervisorUseCase:
     def execute(self, create_data: CreateSupervisorDTO) -> SupervisorResponseDTO:
         #validar CREA
         crea_existente = self.validador_crea.validar(
-            create_data.idendificador_profissional,
-            create_data.name
+            create_data.identificador_profissional,
+            create_data.nome
         )
         if not crea_existente:
             raise ValueError(f"CREA inválido")
@@ -43,26 +43,26 @@ class CriarSupervisorUseCase:
             raise ValueError(f"Email já cadastrado no sistema")
         
         #valida tamanho da senha
-        if len(create_data.password) < 8:
+        if len(create_data.senha) < 8:
              raise ValueError(f"Senha deve conter 8 caracteres")
 
         #garantir hash da senha
-        senha_hash = self.hasher.hash(create_data.password)
+        senha_hash = self.hasher.hash(create_data.senha)
 
         novo_supervisor = Supervisor(
-            name=create_data.name.title(),
+            name=create_data.nome.title(),
             email=create_data.email,
             password=senha_hash,
-            idendificador_profissional=create_data.idendificador_profissional,
+            idendificador_profissional=create_data.identificador_profissional,
             uf=create_data.uf,
             cidade=create_data.cidade
         )
         supervisor_salvo = self.repository.save(novo_supervisor)
         return SupervisorResponseDTO(
             id=supervisor_salvo.id,
-            name=supervisor_salvo.name,
+            nome=supervisor_salvo.name,
             email=supervisor_salvo.email,
-            idendificador_profissional=supervisor_salvo.idendificador_profissional,
+            identificador_profissional=supervisor_salvo.idendificador_profissional,
             uf=supervisor_salvo.uf,
             cidade=supervisor_salvo.cidade
         )

--- a/backend/src/modules/supervisor/application/user_case/uc_02.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_02.py
@@ -28,11 +28,11 @@ class LoginSupervisorUseCase:
         
         # Verifica se está bloqueado
         if supervisor.is_locked():
-            tempo_bloqueio_formatado = supervisor.limite_de_bloqueio.strftime("%d/%m/%Y %H:%M:%S")
+            tempo_bloqueio_formatado = supervisor.limite_de_bloqueio.strftime("%H:%M:%S %d/%m/%Y")
             raise ValueError(f"Você atingiu o limite máximo de erros, tente novamente depois de: {tempo_bloqueio_formatado}")
         
         # Verificar senha
-        if not self.hasher.verify(login_data.password, supervisor.password):
+        if not self.hasher.verify(login_data.senha, supervisor.password):
             
             if supervisor.tentativas_falhas >= 4:
                 tempo_bloqueio = datetime.now(timezone.utc) + timedelta(minutes=15)
@@ -46,16 +46,16 @@ class LoginSupervisorUseCase:
         self.repository.update_tentativas(supervisor.id, 0)
         self.repository.update_tempo_bloqueio(supervisor.id, None)
         
-        # Gerar tokens JWT
-        access_token = self.token_service.generate(supervisor)
-        refresh_token = self.token_service.generate_refresh_token(supervisor)
+        # Gerar tokens JWT com base em "Lembrar-me"
+        access_token = self.token_service.generate(supervisor, login_data.lembrar_me)
+        refresh_token = self.token_service.generate_refresh_token(supervisor, login_data.lembrar_me)
         
         # Retornar resposta com tokens
         return LoginResponseDTO(
-            access_token=access_token,
-            refresh_token=refresh_token,
-            token_type="bearer",
-            user={
+            token_acesso=access_token,
+            token_atualizacao=refresh_token,
+            tipo_token="bearer",
+            usuario={
                 "id": supervisor.id,
                 "name": supervisor.name,
                 "email": supervisor.email,

--- a/backend/src/shared/auth/dtos/token_dto.py
+++ b/backend/src/shared/auth/dtos/token_dto.py
@@ -1,22 +1,31 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 
 
 class LoginDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    
     email: EmailStr
-    password: str
+    senha: str
+    lembrar_me: bool = False
 
 
 class LoginResponseDTO(BaseModel):
-    access_token: str
-    refresh_token: str
-    token_type: str = "bearer"
-    user: dict
+    model_config = ConfigDict(populate_by_name=True)
+    
+    token_acesso: str
+    token_atualizacao: str
+    tipo_token: str = "bearer"
+    usuario: dict
 
 
 class RefreshTokenDTO(BaseModel):
-    refresh_token: str
+    model_config = ConfigDict(populate_by_name=True)
+    
+    token_atualizacao: str
 
 
 class RefreshTokenResponseDTO(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
+    model_config = ConfigDict(populate_by_name=True)
+    
+    token_acesso: str
+    tipo_token: str = "bearer"

--- a/backend/src/shared/auth/jwt_service.py
+++ b/backend/src/shared/auth/jwt_service.py
@@ -14,7 +14,7 @@ if not SECRET or not ALGORITHM:
 
 class JWTService(TokenService):
 
-    def generate(self, user) -> str:
+    def generate(self, user, lembrar_me: bool = False) -> str:
         payload = {
             "sub": str(user.id),
             "role": "supervisor",
@@ -25,12 +25,15 @@ class JWTService(TokenService):
 
         return jwt.encode(payload, SECRET, algorithm=ALGORITHM)
 
-    def generate_refresh_token(self, user) -> str:
+    def generate_refresh_token(self, user, lembrar_me: bool = False) -> str:
+        dias_expiracao = 30 if lembrar_me else 0
+        horas_expiracao = 0 if lembrar_me else 8
+        
         payload = {
             "sub": str(user.id),
             "role": "supervisor",
             "type": "refresh",
-            "exp": datetime.now(timezone.utc) + timedelta(days=7),
+            "exp": datetime.now(timezone.utc) + timedelta(days=dias_expiracao, hours=horas_expiracao),
             "iat": datetime.now(timezone.utc),
         }
 

--- a/backend/src/shared/auth/routes.py
+++ b/backend/src/shared/auth/routes.py
@@ -2,24 +2,30 @@ from fastapi import APIRouter, Depends, HTTPException
 from src.shared.auth.dtos import RefreshTokenDTO, RefreshTokenResponseDTO
 from src.shared.auth.jwt_service import JWTService
 
-router = APIRouter(prefix="/auth", tags=["auth"])
+router = APIRouter(prefix="/auth", tags=["Autenticação"])
 
 
 def get_jwt_service():
     return JWTService()
 
 
-@router.post("/refresh", response_model=RefreshTokenResponseDTO, status_code=200)
+@router.post(
+    "/refresh",
+    response_model=RefreshTokenResponseDTO,
+    status_code=200,
+    summary="Renovar Token de Acesso",
+    description="Usa o refresh token para obter um novo access token sem fazer login novamente"
+)
 async def refresh_token(
     refresh_data: RefreshTokenDTO,
     jwt_service = Depends(get_jwt_service)
 ):
     
     try:
-        new_access_token = jwt_service.refresh_access_token(refresh_data.refresh_token)
+        new_access_token = jwt_service.refresh_access_token(refresh_data.token_atualizacao)
         return RefreshTokenResponseDTO(
-            access_token=new_access_token,
-            token_type="bearer"
+            token_acesso=new_access_token,
+            tipo_token="bearer"
         )
     except Exception as e:
         raise HTTPException(status_code=401, detail=f"Erro ao renovar token: {str(e)}")


### PR DESCRIPTION
# Descrição
Implementação completa do sistema de autenticação do Supervisor com JWT, refresh token e controle de tentativas de acesso.

## Funcionalidades

### 1. **Autenticação JWT**
- Access Token: válido por **15 minutos**
- Refresh Token: 
  - **8 horas** (sem "Lembrar-me")
  - **30 dias** (com "Lembrar-me" ativado)

### 2. **Segurança**
- Hash de senha com Argon2
- Validação de email e CREA integrada
- Bloqueio automático após **5 tentativas** erradas
- Desbloqueio após **15 minutos**

### 3. **Endpoints**
- `POST /supervisores/login` - Autenticar supervisor
- `POST /auth/refresh` - Renovar token de acesso

## DTOs
- `LoginDTO`: email, senha, lembrar_me (boolean)
- `LoginResponseDTO`: token_acesso, token_atualizacao, tipo_token, usuario
- `RefreshTokenDTO`: token_atualizacao
- `RefreshTokenResponseDTO`: token_acesso, tipo_token

## Fluxo
1. Supervisor envia credenciais + `remember_me`
2. Validação de bloqueio/tentativas
3. Hash da senha comparado
4. Geração de tokens com tempo variável
5. Contador de tentativas resetado
6. Retorno dos tokens + dados do usuário

## Tecnologias
- PyJWT + python-jose (tokens)
- Argon2 (hash de senha)


## Extras
- Documentação detalhada dos endpoints no Swagger
- Descrição de cada rota com `summary` e `description`
- Tags em português para melhor organização na API docs