### PR TITLE
fix(auth): adicionando role no DTO retornado no login

### DIFF
--- a/backend/src/modules/supervisor/application/user_case/uc_02.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_02.py
@@ -3,6 +3,7 @@ from src.modules.supervisor.domain.repositories.ISupervisorRepository import ISu
 from src.shared.auth.dtos import LoginDTO, LoginResponseDTO
 from src.shared.security.password_hash import PassWordHasher
 from src.shared.security.token_service import TokenService
+from src.shared.enums.cargo_enum import CargoEnum
 from datetime import datetime, timezone, timedelta
 
 
@@ -47,8 +48,8 @@ class LoginSupervisorUseCase:
         self.repository.update_tempo_bloqueio(supervisor.id, None)
         
         # Gerar tokens JWT com base em "Lembrar-me"
-        access_token = self.token_service.generate(supervisor, login_data.lembrar_me)
-        refresh_token = self.token_service.generate_refresh_token(supervisor, login_data.lembrar_me)
+        access_token = self.token_service.generate(supervisor, CargoEnum.SUPERVISOR.value, login_data.lembrar_me)
+        refresh_token = self.token_service.generate_refresh_token(supervisor, CargoEnum.SUPERVISOR.value, login_data.lembrar_me)
         
         # Retornar resposta com tokens
         return LoginResponseDTO(
@@ -59,6 +60,7 @@ class LoginSupervisorUseCase:
                 "id": supervisor.id,
                 "name": supervisor.name,
                 "email": supervisor.email,
+                "role": CargoEnum.SUPERVISOR
             }
         )
 

--- a/backend/src/shared/auth/jwt_service.py
+++ b/backend/src/shared/auth/jwt_service.py
@@ -2,6 +2,7 @@ import os
 from dotenv import load_dotenv
 from jose import jwt, JWTError
 from src.shared.security.token_service import TokenService
+from src.shared.enums.cargo_enum import CargoEnum
 from datetime import datetime, timezone, timedelta
 
 load_dotenv()
@@ -14,10 +15,10 @@ if not SECRET or not ALGORITHM:
 
 class JWTService(TokenService):
 
-    def generate(self, user, lembrar_me: bool = False) -> str:
+    def generate(self, user, cargo: str, lembrar_me: bool = False) -> str:
         payload = {
             "sub": str(user.id),
-            "role": "supervisor",
+            "role": cargo,
             "type": "access",
             "exp": datetime.now(timezone.utc) + timedelta(minutes=15),
             "iat": datetime.now(timezone.utc),
@@ -25,13 +26,13 @@ class JWTService(TokenService):
 
         return jwt.encode(payload, SECRET, algorithm=ALGORITHM)
 
-    def generate_refresh_token(self, user, lembrar_me: bool = False) -> str:
+    def generate_refresh_token(self, user, cargo: str, lembrar_me: bool = False) -> str:
         dias_expiracao = 30 if lembrar_me else 0
         horas_expiracao = 0 if lembrar_me else 8
         
         payload = {
             "sub": str(user.id),
-            "role": "supervisor",
+            "role": cargo,
             "type": "refresh",
             "exp": datetime.now(timezone.utc) + timedelta(days=dias_expiracao, hours=horas_expiracao),
             "iat": datetime.now(timezone.utc),

--- a/backend/src/shared/enums/cargo_enum.py
+++ b/backend/src/shared/enums/cargo_enum.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class CargoEnum(str, Enum):
+    SUPERVISOR = "supervisor"
+    COLABORADOR = "colaborador"


### PR DESCRIPTION
# JWT Role Enhancement - fix/jwt-role

## Resumo

Refatoração do serviço JWT para receber dinamicamente o cargo (role) como parâmetro na geração de tokens. Esta mudança elimina o hardcoding do cargo "supervisor" e permite reutilizar o JWTService para diferentes tipos de usuários (supervisor, colaborador, etc.), facilitando a autenticação e autorização no frontend.

## Funcionalidades

### 1. JWT Service Parametrizado
- Métodos `generate()` e `generate_refresh_token()` agora recebem o `cargo` como parâmetro
- Remover hardcoding do role "supervisor"
- Suporte para múltiplos cargos (supervisor, colaborador, etc.)

### 2. Enumeração de Cargos
- Novo enum `CargoEnum` com valores padronizados
- `CargoEnum.SUPERVISOR = "supervisor"`
- `CargoEnum.COLABORADOR = "colaborador"`
- Facilita adição de novos cargos no futuro

### 3. Use Case de Login Atualizado
- Passa `CargoEnum.SUPERVISOR.value` ao gerar tokens
- Campo `role` adicionado à resposta de login para confirmação no frontend
- Preparado para reutilização em `LoginColaboradorUseCase`

## Arquivos Modificados

- `backend/src/shared/auth/jwt_service.py` - Parâmetro `cargo: str` adicionado
- `backend/src/shared/enums/cargo_enum.py` - Novo arquivo com enum de cargos
- `backend/src/modules/supervisor/application/user_case/uc_02.py` - Chama `generate()` com cargo

## DTOs

- `LoginResponseDTO`: Agora inclui campo `role` para confirmação do cargo no frontend

```python
{
  "token_acesso": "eyJ0eXAiOiJKV1QiLCJhbGc...",
  "token_atualizacao": "eyJ0eXAiOiJKV1QiLCJhbGc...",
  "tipo_token": "bearer",
  "usuario": {
    "id": 1,
    "name": "João Silva",
    "email": "joao@example.com",
    "role": "supervisor"
  }
}
```


