### PR TITLE
fix(CT_013): validação do campo nome impedindo valores numéricos closes #15

### DIFF
--- a/backend/src/modules/colaborador/api/http/colaborador_routes.py
+++ b/backend/src/modules/colaborador/api/http/colaborador_routes.py
@@ -13,6 +13,7 @@ from src.shared.auth.dependencies import verify_supervisor_role
 from src.shared.validators.email_validator import EmailValidator
 from src.shared.validators.telefone_validator import TelefoneValidator
 from src.shared.infrastructure.email_unico_validator import EmailUnicoValidator
+from src.shared.validators.string_sem_numero_validator import StringSemNumeroValidator
 
 router = APIRouter(tags=["Colaboradores"])
 
@@ -33,6 +34,9 @@ def get_email_sender():
 
 def get_email_validator():
     return EmailValidator()
+
+def get_string_validator():
+    return StringSemNumeroValidator()
 
 def get_telefone_validator():
     return TelefoneValidator()
@@ -57,7 +61,8 @@ async def criar_colaborador(
     email_sender = Depends(get_email_sender),
     email_validator = Depends(get_email_validator),
     telefone_validator = Depends(get_telefone_validator),
-    email_unico_validator = Depends(get_email_unico_validator)
+    email_unico_validator = Depends(get_email_unico_validator),
+    string_validator = Depends(get_string_validator)
 ):
     try:
         use_case = CriarColaboradorUseCase(
@@ -68,7 +73,8 @@ async def criar_colaborador(
             email_sender=email_sender,
             email_validator=email_validator,
             telefone_validator=telefone_validator,
-            email_unico_validator=email_unico_validator
+            email_unico_validator=email_unico_validator,
+            string_sem_numero_validator=string_validator
         )
         return use_case.execute(create_data)
     except ValueError as e:

--- a/backend/src/modules/colaborador/application/use_case/uc_04.py
+++ b/backend/src/modules/colaborador/application/use_case/uc_04.py
@@ -11,6 +11,7 @@ from src.shared.domain.interfaces.INotificacaoService import INotificacaoService
 from src.shared.domain.interfaces.i_email_validator import IEmailValidator
 from src.shared.domain.interfaces.i_telefone_validator import ITelefoneValidator
 from src.shared.domain.interfaces.i_email_unico_validator import IEmailUnicoValidator
+from src.shared.domain.interfaces.i_string_sem_numeros_validator import IStringSemNumeroValidador
 
 class CriarColaboradorUseCase:
 
@@ -23,7 +24,8 @@ class CriarColaboradorUseCase:
             email_sender: INotificacaoService,
             email_validator: IEmailValidator,
             telefone_validator: ITelefoneValidator,
-            email_unico_validator: IEmailUnicoValidator
+            email_unico_validator: IEmailUnicoValidator,
+            string_sem_numero_validator: IStringSemNumeroValidador
         ):
         self.repository = repository
         self.repository_supervisor = repository_supervisor
@@ -33,12 +35,19 @@ class CriarColaboradorUseCase:
         self.email_validator = email_validator
         self.telefone_validator = telefone_validator
         self.email_unico_validator = email_unico_validator
+        self.string_sem_numero_validator = string_sem_numero_validator
 
     def execute(self, create_data: CreateColaboradorDTO) -> ColaboradorResponseDTO:
 
         supervisor_existente = self.repository_supervisor.find_by_id(
             create_data.id_profissional_responsavel
         )
+
+        #valida nome e formata nome
+        nome_formatado = self.string_sem_numero_validator.formatar_string_sem_numero(create_data.nome).title()
+
+        if not self.string_sem_numero_validator.validar_string_sem_numero(nome_formatado):
+            raise ValueError(f"Nome deve incluir apenas letras")
 
         #valida identificador do supervisor
         if supervisor_existente == None:
@@ -63,7 +72,7 @@ class CriarColaboradorUseCase:
         
         try:
             novo_colaborador = Colaborador(
-                nome=create_data.nome.title(),
+                nome=nome_formatado,
                 id_profissional_responsavel=create_data.id_profissional_responsavel,
                 is_tecnico=create_data.is_tecnico,
                 email=create_data.email,

--- a/backend/src/modules/supervisor/application/user_case/uc_01.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_01.py
@@ -36,6 +36,11 @@ class CriarSupervisorUseCase:
         # if not crea_existente:
         #     raise ValueError(f"CREA inválido")
 
+        nome_formatado = self.string_sem_numero_validator.formatar_string_sem_numero(create_data.nome).title()
+
+        if not self.string_sem_numero_validator.validar_string_sem_numero(nome_formatado):
+            raise ValueError(f"Nome deve incluir apenas letras")
+
         # Validar UF
         if not UFEnum.is_valid(create_data.uf):
             raise ValueError(f"UF inválida")
@@ -48,7 +53,7 @@ class CriarSupervisorUseCase:
         if self.email_unico_validator.validar_email_unico(create_data.email):
             raise ValueError(f"Email já cadastrado no sistema")
 
-        cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(create_data.cidade)
+        cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(create_data.cidade).title()
 
         if not self.string_sem_numero_validator.validar_string_sem_numero(cidade_formatada):
             raise ValueError(f"Cidade deve incluir apenas letras")
@@ -66,12 +71,12 @@ class CriarSupervisorUseCase:
         senha_hash = self.hasher.hash(create_data.senha)
 
         novo_supervisor = Supervisor(
-            name=create_data.nome.title(),
+            name=nome_formatado,
             email=create_data.email,
             password=senha_hash,
             idendificador_profissional=create_data.identificador_profissional,
             uf=create_data.uf,
-            cidade=cidade_formatada.title()
+            cidade=cidade_formatada
         )
         supervisor_salvo = self.repository.save(novo_supervisor)
         return SupervisorResponseDTO(


### PR DESCRIPTION
## Descrição
Implementa validação no campo **Nome** para impedir a inserção de valores numéricos, corrigindo o bug identificado no cadastro de usuários.

## Problema
O sistema permitia o cadastro de nomes contendo apenas números, violando a regra de negócio.

## Solução
- Criação/uso de validador para strings sem números
- Aplicação de regex para validação do campo nome
- Bloqueio do fluxo de cadastro em caso de valor inválido

## Regra aplicada
- Nome deve conter apenas letras (incluindo acentuação), espaços e hífens
- Regex utilizada:

## US Afetadas
- US 01
- US 04
## Rotas Afetadas
- POST /api/supervisores
- POST /api/colaboradores

## Resultado
- Cadastro com nome inválido é rejeitado
- Mensagem de erro padronizada é retornada