### PR TITLE
 fix(CT_033): validação do campo de data no cadastro de colaborador para datas no passado

### DIFF
--- a/backend/src/modules/colaborador/application/use_case/uc_04.py
+++ b/backend/src/modules/colaborador/application/use_case/uc_04.py
@@ -61,11 +61,29 @@ class CriarColaboradorUseCase:
         if self.email_unico_validator.validar_email_unico(create_data.email):
             raise ValueError(f"Email já cadastrado no sistema")
 
-        if not create_data.is_tecnico and create_data.limite_acesso is None:
-            raise ValueError("A data de expiração do acesso é obrigatória para colaborador")
-        
+        limite = create_data.limite_acesso
+
+        if create_data.is_tecnico:
+            limite = None
+        else:
+            print(limite, datetime.now(timezone.utc) )
+            if limite is None:
+                raise ValueError("A data de expiração do acesso é obrigatória para colaborador")
+            if limite.tzinfo is None:
+                limite = limite.replace(tzinfo=timezone.utc)
+            print(limite, datetime.now(timezone.utc) )
+            agora = datetime.now(timezone.utc)
+
+            if limite < agora:
+                raise ValueError("A data de acesso deve ser igual ou posterior ao momento atual.")
+
+        create_data.limite_acesso = limite
+
         #gerar senha
         senha = self.criador_senha.gerar_senha()
+
+        if create_data.is_tecnico:
+            create_data.limite_acesso = None
 
         #garantir hash da senha
         senha_hash = self.hasher.hash(senha)

--- a/frontend/src/app/editar-perfil/page.tsx
+++ b/frontend/src/app/editar-perfil/page.tsx
@@ -184,7 +184,11 @@ export default function PerfilEngenheiro() {
         is_tecnico: tipoEquipe === 'TECNICO',
         email: convite.email.trim(),
         cft: tipoEquipe === 'TECNICO' ? convite.cft.trim() : null,
-        limite_acesso: tipoEquipe === 'COLABORADOR' ? `${convite.limiteAcesso}T00:00:00` : null,
+        limite_acesso: tipoEquipe === 'COLABORADOR' && convite.limiteAcesso
+          ? new Date(
+              `${convite.limiteAcesso}T23:59:59`
+            ).toISOString()
+          : null,
       };
 
       console.log('Payload a enviar:', payload);


### PR DESCRIPTION
### **Descrição**

O sistema estava permitindo o cadastro de colaboradores com **data de expiração do acesso no passado**, o que viola a regra de negócio esperada.

Além disso, em alguns cenários, ocorria erro ao comparar datas devido à inconsistência de timezone (`offset-naive vs offset-aware`).

---

### **Passos para reproduzir**

1. Acessar a tela de cadastro de colaborador
2. Selecionar o tipo "Colaborador"
3. Informar uma data anterior ao dia atual
4. Submeter o formulário

---

### **Comportamento esperado**

* O sistema deve impedir o cadastro com data no passado
* A data deve ser **igual ou posterior ao momento atual**

---

### **Comportamento atual**

* O sistema aceitava datas no passado em alguns cenários
* Em outros casos, lançava erro:

```id="8o6h2u"
can't compare offset-naive and offset-aware datetimes
```

---

### **Causa raiz**

* Ausência de validação consistente de data no backend
* Comparação entre datas com e sem timezone
* Interpretação incorreta da data enviada pelo frontend

---

### **Solução aplicada**

#### **Frontend**

* Ajuste no envio da data para garantir consistência em UTC e considerar fim do dia:

```ts id="3y7u0l"
limite_acesso: tipoEquipe === 'COLABORADOR' && convite.limiteAcesso
  ? new Date(`${convite.limiteAcesso}T23:59:59`).toISOString()
  : null,
```

---

#### **Backend**

* Validação obrigatória da data para colaboradores
* Normalização de timezone antes da comparação
* Bloqueio de datas no passado:

```python id="lm5d4t"
if limite is None:
    raise ValueError("A data de expiração do acesso é obrigatória para colaborador")

if limite.tzinfo is None:
    limite = limite.replace(tzinfo=timezone.utc)

if limite < datetime.now(timezone.utc):
    raise ValueError("A data de acesso deve ser igual ou posterior ao momento atual.")
```

---

### **Resultado após correção**

* Não é mais possível cadastrar colaborador com data no passado
* Comparação de datas funciona corretamente
* Erro de timezone não ocorre mais

---

### **Observações**

* Regra de negócio agora está garantida no backend (não depende do frontend)
* Padronização de datas em UTC para evitar inconsistências

