### PR TITLE
fix(CT_06B): validação do campo nome impedindo valores numéricos closes #34

### DIFF
--- a/backend/src/modules/colaborador/application/use_case/uc_04.py
+++ b/backend/src/modules/colaborador/application/use_case/uc_04.py
@@ -54,8 +54,11 @@ class CriarColaboradorUseCase:
             raise ValueError(f"Supervisor com identificador: {create_data.id_profissional_responsavel} não cadastrado no sistema")
         
         # Validar formato do email
-        if not self.email_validator.validar_email(create_data.email):
+        email_formatado = create_data.email.strip().lower()
+        if not self.email_validator.validar_email(email_formatado):
             raise ValueError(f"Email inválido")
+        
+        create_data.email = email_formatado
         
         # Validar se o email já existe (consulta única UNION em ambas tabelas)
         if self.email_unico_validator.validar_email_unico(create_data.email):

--- a/backend/src/modules/supervisor/application/user_case/uc_01.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_01.py
@@ -46,8 +46,12 @@ class CriarSupervisorUseCase:
             raise ValueError(f"UF inválida")
         
         # Validar formato do email
-        if not self.email_validator.validar_email(create_data.email):
+        email_formatado = create_data.email.strip().lower()
+
+        if not self.email_validator.validar_email(email_formatado):
             raise ValueError(f"Email inválido")
+        
+        create_data.email = email_formatado
         
         # Validar se o email já existe (consulta única UNION em ambas tabelas)
         if self.email_unico_validator.validar_email_unico(create_data.email):


### PR DESCRIPTION
**Descrição**
O sistema não normalizava o e-mail antes da validação, permitindo inconsistências ao cadastrar ou validar usuários com letras maiúsculas. Isso podia causar falhas na validação ou duplicidade de contas com o mesmo e-mail em formatos diferentes.

**Alteração realizada**
Foi adicionada a normalização do e-mail para letras minúsculas antes da validação e persistência:

```python
email_formatado = create_data.email.strip().lower()
if not self.email_validator.validar_email(email_formatado):
    raise ValueError(f"Email inválido")

create_data.email = email_formatado
```

**Resultado esperado**
Todos os e-mails passam a ser tratados como case-insensitive, garantindo consistência na validação e evitando duplicidades por diferença de capitalização.

**Observação**
Agora a validação ocorre sempre com o e-mail normalizado, independentemente de como o usuário o digitou.
