### PR TITLE
refactor(login): adicionando redis e limitador de tentativas para IP

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,9 @@ POSTGRES_DB=smv
 # Database URL (Docker)
 DATABASE_URL=postgresql://postgres:your_secure_password_here@postgres:5432/smv
 
+# Redis
+REDIS_URL=redis://localhost:6379/0
+
 # CREA API Configuration
 CREA_API_KEY=your_api_key_here
 CREA_API_URL=https://www.consultacrea.com.br/api/index.php

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from src.shared.infrastructure.db import create_tables, sync_schema
+from src.shared.infrastructure.redis_config import RedisClient
 from src.modules.supervisor.api.http.supervisor_routes import router as supervisor_router
 from src.modules.colaborador.api.http.colaborador_routes import router as colaborador_router
 from src.modules.auth.api.http.auth_routes import router as auth_router
@@ -24,6 +25,28 @@ create_tables()
 
 # Sincronizar schema com as entidades
 sync_schema()
+
+# Lifecycle events para Redis
+@app.on_event("startup")
+async def startup_event():
+    """Inicializa a conexão com Redis ao iniciar a aplicação"""
+    try:
+        redis_client = await RedisClient.get_client()
+        # Testar conexão
+        await redis_client.ping()
+        print("✓ Conexão com Redis estabelecida com sucesso")
+    except Exception as e:
+        print(f"✗ Erro ao conectar com Redis: {str(e)}")
+        raise
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Fecha a conexão com Redis ao desligar a aplicação"""
+    try:
+        await RedisClient.close_client()
+        print("✓ Conexão com Redis fechada com sucesso")
+    except Exception as e:
+        print(f"✗ Erro ao fechar conexão com Redis: {str(e)}")
 
 app.include_router(auth_router)
 app.include_router(supervisor_router, prefix="/api/supervisores", tags=["Supervisores"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ argon2-cffi>=21.3.0
 python-jose[cryptography]>=3.3.0
 email-validator>=2.0.0
 alembic>=1.13.0
+redis>=5.0.0

--- a/backend/src/modules/auth/api/http/auth_routes.py
+++ b/backend/src/modules/auth/api/http/auth_routes.py
@@ -1,14 +1,18 @@
 from typing import Annotated
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
+from datetime import datetime
 from src.shared.infrastructure.db import get_session
+from src.shared.infrastructure.redis_config import RedisClient
 from src.modules.auth.application.dtos.login_dto import LoginDTO, LoginResponseDTO, RefreshTokenDTO, RefreshTokenResponseDTO
 from src.modules.auth.application.use_cases.login_use_case import LoginUseCase
 from src.modules.auth.application.use_cases.refresh_token_use_case import RefreshTokenUseCase
 from src.modules.auth.infrastructure.repositories.generic_user_repository import GenericUserRepository
+from src.modules.auth.infrastructure.services.limitador_redis import LimitadorRedis
 from src.modules.supervisor.infrastructure.security.argon2_hasher import Argon2PasswordHasher
 from src.shared.auth.jwt_service import JWTService
 from src.shared.auth.dependencies import verify_supervisor_role
+import asyncio
 from src.modules.supervisor.application.dtos.supervisor_dto import SupervisorResponseDTO
 
 router = APIRouter(prefix="/auth", tags=["Autenticação"])
@@ -26,6 +30,19 @@ def get_token_service():
     return JWTService()
 
 
+async def get_limitador():
+    """Dependency para obter instância do limitador Redis"""
+    redis_client = await RedisClient.get_client()
+    return LimitadorRedis(redis_client)
+
+
+def get_client_ip(request: Request) -> str:
+    """Extrai o IP do cliente (considerando proxy)"""
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
 @router.post(
     "/login",
     response_model=LoginResponseDTO,
@@ -35,15 +52,35 @@ def get_token_service():
 )
 async def login(
     login_data: LoginDTO,
+    request: Request,
     repository = Depends(get_repository),
     hasher = Depends(get_hasher),
-    token_service = Depends(get_token_service)
+    token_service = Depends(get_token_service),
+    limitador = Depends(get_limitador)
 ):
     try:
-        use_case = LoginUseCase(repository, hasher, token_service)
-        return use_case.execute(login_data)
+        ip_user = get_client_ip(request)
+        use_case = LoginUseCase(repository, hasher, token_service, limitador)
+        return await use_case.execute(login_data, ip_user)
     except ValueError as e:
-        raise HTTPException(status_code=401, detail=str(e))
+        detail = str(e)
+        if detail.isdigit():
+            tentativas = int(detail)
+            if tentativas >= 5:
+                proxima_tentativa = await limitador.obter_proxima_tentativa(ip_user)
+                raise HTTPException(
+                    status_code=429,
+                    detail={
+                        "tentativas": tentativas,
+                        "proxima_tentativa": proxima_tentativa.isoformat() if proxima_tentativa else None,
+                        "mensagem": "Você excedeu o limite de tentativas. Tente novamente no horário indicado."
+                    }
+                )
+            raise HTTPException(
+                status_code=401,
+                detail={"tentativas": tentativas, "mensagem": "Email ou senha inválidos"}
+            )
+        raise HTTPException(status_code=401, detail=detail)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao fazer login: {str(e)}")
 
@@ -85,7 +122,7 @@ async def get_logged_supervisor(
             raise HTTPException(status_code=401, detail="Token inválido")
 
         user_id = int(str(user_id_raw))
-        supervisor = repository.find_by_id(user_id)
+        supervisor = await asyncio.to_thread(repository.find_by_id, user_id)
         if not supervisor:
             raise HTTPException(status_code=404, detail="Supervisor não encontrado")
         return SupervisorResponseDTO(

--- a/backend/src/modules/auth/application/use_cases/login_use_case.py
+++ b/backend/src/modules/auth/application/use_cases/login_use_case.py
@@ -3,6 +3,8 @@ from src.modules.auth.infrastructure.repositories.generic_user_repository import
 from src.shared.security.password_hash import PassWordHasher
 from src.shared.security.token_service import TokenService
 from datetime import datetime, timezone, timedelta
+from src.modules.auth.domain.repositories.i_limitador_tentativas import LimitadorDeTentativas
+import asyncio
 
 
 class LoginUseCase:
@@ -10,18 +12,26 @@ class LoginUseCase:
             self,
             repository: GenericUserRepository,
             hasher: PassWordHasher,
-            token_service: TokenService
+            token_service: TokenService,
+            limitador: LimitadorDeTentativas
         ):
         self.repository = repository
         self.hasher = hasher
         self.token_service = token_service
+        self.limitador = limitador
 
-    def execute(self, login_data: LoginDTO) -> LoginResponseDTO:
-        # Buscar usuário (supervisor ou colaborador)
-        user_info = self.repository.find_by_email(login_data.email)
+    async def execute(self, login_data: LoginDTO, ip_user: str) -> LoginResponseDTO:
+        # Verifica se está bloqueado por tentativas falhas (rate limiting)
+        if await self.limitador.esta_bloqueado(ip_user):
+            tentativas = await self.limitador.obter_tentativas(ip_user)
+            raise ValueError(str(tentativas))
+        
+        # Buscar usuário (supervisor ou colaborador) em thread separado (DB sync)
+        user_info = await asyncio.to_thread(self.repository.find_by_email, login_data.email)
         
         if not user_info:
-            raise ValueError("Email ou senha inválidos")
+            tentativas = await self.limitador.registrar_tentativa(ip_user)
+            raise ValueError(str(tentativas))
         
         user = user_info["user"]
         user_type = user_info["user_type"]
@@ -30,10 +40,13 @@ class LoginUseCase:
         limite_acesso = user_info["limite_acesso"]
         acesso_liberado = user_info["acesso_liberado"]
         
-        # Verifica se está bloqueado
-        if self._is_locked(user):
-            tempo_bloqueio_formatado = user.limite_de_bloqueio.strftime("%H:%M:%S %d/%m/%Y")
-            raise ValueError(f"Você atingiu o limite máximo de erros, tente novamente depois de: {tempo_bloqueio_formatado}")
+        # Verificar senha
+        if not self.hasher.verify(login_data.senha, password_field):
+            tentativas = await self.limitador.registrar_tentativa(ip_user)
+            raise ValueError(str(tentativas))
+        
+        # Reset de tentativas após login bem-sucedido
+        await self.limitador.resetar(ip_user)
         
         # Verificação de acesso do colaborador
         if cargo == "colaborador":
@@ -42,22 +55,6 @@ class LoginUseCase:
             
             if limite_acesso is not None and datetime.now(timezone.utc) > limite_acesso:
                 raise ValueError(f"Você não possui mais acesso ao sistema, entre em contato com seu supervisor")
-        
-        # Verificar senha
-        if not self.hasher.verify(login_data.senha, password_field):
-            
-            if user.tentativas_falhas >= 4:
-                tempo_bloqueio = datetime.now(timezone.utc) + timedelta(minutes=15)
-                self.repository.update_lock_time(user_type, user.id, tempo_bloqueio)
-                tempo_bloqueio_formatado = tempo_bloqueio.strftime("%d/%m/%Y %H:%M:%S")
-                raise ValueError(f"Você atingiu o limite máximo de erros, tente novamente depois de: {tempo_bloqueio_formatado}")
-            
-            self.repository.update_failed_attempts(user_type, user.id, user.tentativas_falhas + 1)
-            raise ValueError("Email ou senha inválidos")
-        
-        # Reset tentativas e limite de bloqueio
-        self.repository.update_failed_attempts(user_type, user.id, 0)
-        self.repository.update_lock_time(user_type, user.id, None)
         
         # Gerar tokens JWT
         access_token = self.token_service.generate(user, cargo, login_data.lembrar_me)
@@ -78,8 +75,3 @@ class LoginUseCase:
                 "cargo": cargo
             }
         )
-    
-    def _is_locked(self, user) -> bool:
-        if user.limite_de_bloqueio is None:
-            return False
-        return datetime.now(timezone.utc) < user.limite_de_bloqueio

--- a/backend/src/modules/auth/domain/repositories/i_limitador_tentativas.py
+++ b/backend/src/modules/auth/domain/repositories/i_limitador_tentativas.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+class LimitadorDeTentativas(ABC):
+    @abstractmethod
+    async def esta_bloqueado(self, identificador: str) -> bool:
+        pass
+
+    @abstractmethod
+    async def registrar_tentativa(self, identificador: str) -> int:
+        pass
+
+    @abstractmethod
+    async def obter_tentativas(self, identificador: str) -> int:
+        pass
+
+    @abstractmethod
+    async def obter_proxima_tentativa(self, identificador: str) -> datetime | None:
+        pass
+
+    @abstractmethod
+    async def resetar(self, identificador: str) -> None:
+        pass

--- a/backend/src/modules/auth/infrastructure/services/limitador_redis.py
+++ b/backend/src/modules/auth/infrastructure/services/limitador_redis.py
@@ -1,0 +1,36 @@
+from src.modules.auth.domain.repositories.i_limitador_tentativas import LimitadorDeTentativas
+from redis.asyncio import Redis
+from datetime import datetime, timezone, timedelta
+
+class LimitadorRedis(LimitadorDeTentativas):
+    def __init__(self, client: Redis):
+        self.redis = client
+        self.limite = 5
+        self.expiracao = 900
+
+    async def esta_bloqueado(self, identificador: str) -> bool:
+        valor = await self.redis.get(f"brute_force:{identificador}")
+        return valor is not None and int(valor) >= self.limite
+
+    async def registrar_tentativa(self, identificador: str) -> int:
+        chave = f"brute_force:{identificador}"
+        novo_valor = await self.redis.incr(chave)
+        if novo_valor == 1:
+            await self.redis.expire(chave, self.expiracao)
+        return novo_valor
+
+    async def obter_tentativas(self, identificador: str) -> int:
+        valor = await self.redis.get(f"brute_force:{identificador}")
+        return int(valor) if valor is not None else 0
+
+    async def obter_proxima_tentativa(self, identificador: str):
+        chave = f"brute_force:{identificador}"
+        ttl = await self.redis.ttl(chave)
+
+        if ttl is None or ttl < 0:
+            return None
+
+        return datetime.now(timezone.utc) + timedelta(seconds=ttl)
+
+    async def resetar(self, identificador: str) -> None:
+        await self.redis.delete(f"brute_force:{identificador}")

--- a/backend/src/modules/auth/infrastructure/services/limitador_redis.py
+++ b/backend/src/modules/auth/infrastructure/services/limitador_redis.py
@@ -15,7 +15,8 @@ class LimitadorRedis(LimitadorDeTentativas):
     async def registrar_tentativa(self, identificador: str) -> int:
         chave = f"brute_force:{identificador}"
         novo_valor = await self.redis.incr(chave)
-        if novo_valor == 1:
+        # Definir TTL somente quando atingir o limite (lock-on-threshold)
+        if novo_valor == self.limite:
             await self.redis.expire(chave, self.expiracao)
         return novo_valor
 

--- a/backend/src/shared/infrastructure/redis_config.py
+++ b/backend/src/shared/infrastructure/redis_config.py
@@ -1,0 +1,21 @@
+import redis.asyncio as redis
+import os
+
+class RedisClient:
+    _instance = None
+
+    @classmethod
+    async def get_client(cls):
+        if cls._instance is None:
+            cls._instance = redis.from_url(
+                os.getenv("REDIS_URL", "redis://localhost:6379"),
+                encoding="utf-8",
+                decode_responses=True
+            )
+        return cls._instance
+
+    @classmethod
+    async def close_client(cls):
+        if cls._instance:
+            await cls._instance.close()
+            cls._instance = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,19 @@
 services:
+  redis:
+    image: redis:7-alpine
+    container_name: smp_redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - smp_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   postgres:
     image: postgres:15-alpine
     container_name: smp_postgres
@@ -28,6 +43,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - ./backend/src:/app/src
       - ./backend/main.py:/app/main.py
@@ -53,6 +70,7 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
 
 networks:
   smp_network:


### PR DESCRIPTION
## Descrição
Integração do Redis para controle de tentativas de login por IP, melhorias no fluxo de autenticação (uso de `asyncio.to_thread` para chamadas de banco sincronas) e responses mais explícitas quando o IP for bloqueado.

## O que foi feito
- Adicionado serviço `redis` no docker-compose.yml e volume persistente (`redis_data`).
- Implementado `RedisClient` e lifecycle de conexão em main.py (startup/shutdown).
- Implementado `LimitadorRedis` (backend/src/modules/auth/infrastructure/services/limitador_redis.py) para:
  - registrar tentativas por chave `brute_force:<ip>`
  - expirar chave (TTL) ao ultimo incremento
  - retornar contador atual e calcular hora de desbloqueio via `TTL`
- Atualizada interface `LimitadorDeTentativas` com métodos assíncronos e novas operações (`obter_tentativas`, `obter_proxima_tentativa`).
- Ajustado `LoginUseCase` para:
  - usar `asyncio.to_thread` ao chamar métodos de repositório que são síncronos (evita bloquear event loop)
  - integrar `LimitadorRedis` (contagem por IP)
  - retornar apenas o contador de tentativas em erros (consistência com rota)
- Atualizado `auth_routes` para:
  - usar dependency `get_limitador()` e extrair IP do `Request`
  - interpretar o erro numérico e retornar `401` com `{tentativas, mensagem}` até atingir o limite, e `429` com `{tentativas, proxima_tentativa, mensagem}` quando bloqueado
- Atualizado .env padrão com `REDIS_URL=redis://redis:6379/0`

## Arquivos alterados (principais)
- docker-compose.yml
- .env
- main.py
- i_limitador_tentativas.py
- limitador_redis.py
- login_use_case.py
- auth_routes.py

## Endpoints afetados
- `POST /auth/login` — agora aplica rate limiting por IP; em caso de bloqueio retorna `429` com hora de próxima tentativa.
- `POST /auth/refresh` — sem alterações funcionais (mantido).

## DTOs / Responses
- `LoginResponseDTO` permanece igual para sucesso.
- Em falhas de autenticação:
  - Ainda retorna `401` para credenciais inválidas; o `detail` é um objeto: `{ "tentativas": N, "mensagem": "Email ou senha inválidos" }`.
  - Quando o IP atingiu o limite: retorna `429` com `detail`:
    ```
    {
      "tentativas": 5,
      "proxima_tentativa": "2026-04-28T15:42:10.123456+00:00",
      "mensagem": "Você excedeu o limite de tentativas. Tente novamente no horário indicado."
    }
    ```

## Comportamento atual do TTL
- O TTL (15 minutos) é definido na **5** tentativa (`EXPIRE` quando contador passa a 5). Ou seja, o tempo até o desbloqueio decairá a partir do momento em que atingiu 5.

## Como testar localmente

1. Subir containers:
```bash
docker compose up -d --build
```

2. Fazer tentativas de login (credenciais erradas) a partir do mesmo IP (ex.: usando curl):
```bash
curl -i -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"nao@existe.test","senha":"123"}'
```
Repita 5 vezes; as respostas devem ser:
- Primeiras: `401` com `{"tentativas": 1, ...}` até `4`
- Ao atingir 5: `429` com `proxima_tentativa` no `detail`

3. Verificar chaves no Redis:
```bash
docker exec -it smp_redis redis-cli
KEYS brute_force:*
TTL brute_force:<seu_ip>
GET brute_force:<seu_ip>
```

4. Limpar tentativas para testar novamente:
```bash
docker exec -it smp_redis redis-cli DEL brute_force:<seu_ip>
# ou limpar tudo
docker exec -it smp_redis redis-cli FLUSHDB
```


## Notas para reviewer
- Principais mudanças em autenticação: atenção ao uso de `asyncio.to_thread` para garantir que chamadas síncronas de repositório não bloqueiem FastAPI.
- Verificar se o volume `redis_data` é aceitável em ambiente dev; em CI/testes pode ser necessário `FLUSHDB` entre runs.

closes #21