### PR TITLE
feat: implementação backend do caso de uso de atualizar perfil (US_08)

### DIFF
--- a/backend/src/modules/colaborador/api/http/colaborador_routes.py
+++ b/backend/src/modules/colaborador/api/http/colaborador_routes.py
@@ -3,13 +3,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from src.shared.infrastructure.db import get_session
 from src.modules.colaborador.application.use_case.uc_04 import CriarColaboradorUseCase
-from src.modules.colaborador.application.dtos.colaborador_dto import CreateColaboradorDTO, ColaboradorResponseDTO
+from src.modules.colaborador.application.use_case.uc_05 import AtualizarColaboradorUseCase
+from src.modules.colaborador.application.dtos.colaborador_dto import CreateColaboradorDTO, ColaboradorResponseDTO, UpdateColaboradorDTO
 from src.modules.colaborador.infrastructure.repositories.ColaboradorRepository import ColaboradorRepository
 from src.modules.supervisor.infrastructure.repositories.SupervisorRepository import SupervisorRepository
 from src.modules.supervisor.infrastructure.security.argon2_hasher import Argon2PasswordHasher
 from src.shared.infrastructure.secret_criador_senha import SecretCriadorSenha 
 from src.modules.noticacao.infrastructure.SmtpEmailNotificacao import SmtpEmailNotificacaoService
-from src.shared.auth.dependencies import verify_supervisor_role
+from src.shared.auth.dependencies import verify_supervisor_role, verify_any_user
 from src.shared.validators.email_validator import EmailValidator
 from src.shared.validators.telefone_validator import TelefoneValidator
 from src.shared.infrastructure.email_unico_validator import EmailUnicoValidator
@@ -119,3 +120,43 @@ async def deletar_colaborador(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao deletar colaborador: {str(e)}")
+
+
+@router.put(
+    "/me",
+    response_model=ColaboradorResponseDTO,
+    status_code=200,
+    summary="Atualizar meu perfil de colaborador",
+    description="Atualiza apenas o perfil do usuário autenticado usando o sub do JWT, sem aceitar id pelo cliente"
+)
+async def atualizar_meu_perfil(
+    update_data: UpdateColaboradorDTO,
+    payload: Annotated[dict, Depends(verify_any_user)],
+    colaborador_repo = Depends(get_colaborador_repository),
+    string_validator = Depends(get_string_validator),
+    telefone_validator = Depends(get_telefone_validator),
+):
+    try:
+        if payload.get("role") not in {"colaborador", "tecnico"}:
+            raise HTTPException(
+                status_code=403,
+                detail="Este endpoint é exclusivo para colaboradores autenticados"
+            )
+
+        user_id_raw = payload.get("sub")
+        if not user_id_raw:
+            raise HTTPException(status_code=401, detail="Token inválido")
+
+        colaborador_id = int(str(user_id_raw))
+        use_case = AtualizarColaboradorUseCase(
+            colaborador_repo,
+            string_validator,
+            telefone_validator,
+        )
+        return use_case.execute(colaborador_id, update_data)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Erro ao atualizar colaborador: {str(e)}")

--- a/backend/src/modules/colaborador/application/dtos/colaborador_dto.py
+++ b/backend/src/modules/colaborador/application/dtos/colaborador_dto.py
@@ -13,6 +13,17 @@ class CreateColaboradorDTO(BaseModel):
     limite_acesso: Optional[datetime] = None
 
 
+class UpdateColaboradorDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    nome: str
+    uf: Optional[str] = None
+    cidade: Optional[str] = None
+    empresa_ou_orgao: Optional[str] = None
+    telefone: Optional[str] = None
+    instituicao_ensino: Optional[str] = None
+
+
 class ColaboradorResponseDTO(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     
@@ -22,6 +33,11 @@ class ColaboradorResponseDTO(BaseModel):
     is_tecnico: bool
     email: EmailStr
     cft: Optional[str] = None
+    uf: Optional[str] = None
+    cidade: Optional[str] = None
+    empresa_ou_orgao: Optional[str] = None
+    telefone: Optional[str] = None
+    instituicao_ensino: Optional[str] = None
     limite_acesso: Optional[datetime] = None
     acesso_liberado: bool = False
     status: str = "Ativo"

--- a/backend/src/modules/colaborador/application/use_case/uc_05.py
+++ b/backend/src/modules/colaborador/application/use_case/uc_05.py
@@ -1,0 +1,85 @@
+from src.modules.colaborador.application.dtos.colaborador_dto import UpdateColaboradorDTO, ColaboradorResponseDTO
+from src.modules.colaborador.domain.entities.colaborador import Colaborador
+from src.modules.colaborador.domain.repositories.IColaboradorRepository import IColaboradorRepository
+from src.shared.domain.interfaces.i_string_sem_numeros_validator import IStringSemNumeroValidador
+from src.shared.domain.interfaces.i_telefone_validator import ITelefoneValidator
+from src.shared.enums.uf_enum import UFEnum
+
+
+class AtualizarColaboradorUseCase:
+
+    def __init__(
+        self,
+        repository: IColaboradorRepository,
+        string_sem_numero_validator: IStringSemNumeroValidador,
+        telefone_validator: ITelefoneValidator,
+    ):
+        self.repository = repository
+        self.string_sem_numero_validator = string_sem_numero_validator
+        self.telefone_validator = telefone_validator
+
+    def execute(self, colaborador_id: int, update_data: UpdateColaboradorDTO) -> ColaboradorResponseDTO:
+        colaborador_atual = self.repository.find_by_id(colaborador_id)
+
+        if colaborador_atual is None:
+            raise ValueError("Colaborador não encontrado")
+
+        nome_formatado = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.nome).title()
+        if not self.string_sem_numero_validator.validar_string_sem_numero(nome_formatado):
+            raise ValueError("Nome deve incluir apenas letras")
+
+        cidade_formatada = colaborador_atual.cidade
+        if update_data.cidade is not None:
+            cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.cidade).title()
+            if not self.string_sem_numero_validator.validar_string_sem_numero(cidade_formatada):
+                raise ValueError("Cidade deve incluir apenas letras")
+
+        uf = colaborador_atual.uf
+        if update_data.uf is not None:
+            if not UFEnum.is_valid(update_data.uf):
+                raise ValueError("UF inválida")
+            uf = update_data.uf
+
+        empresa_ou_orgao = colaborador_atual.empresa_ou_orgao
+        if update_data.empresa_ou_orgao is not None:
+            empresa_ou_orgao = update_data.empresa_ou_orgao.strip() or None
+
+        instituicao_ensino = colaborador_atual.instituicao_ensino
+        if update_data.instituicao_ensino is not None:
+            instituicao_ensino = update_data.instituicao_ensino.strip() or None
+
+        telefone = colaborador_atual.telefone
+        if update_data.telefone is not None:
+            telefone_limpo = update_data.telefone.strip()
+            if telefone_limpo:
+                if not self.telefone_validator.validar_telefone(telefone_limpo):
+                    raise ValueError("Telefone inválido")
+                telefone = self.telefone_validator.formatar_telefone(telefone_limpo)
+            else:
+                telefone = None
+
+        colaborador_atual.nome = nome_formatado
+        colaborador_atual.uf = uf
+        colaborador_atual.cidade = cidade_formatada
+        colaborador_atual.empresa_ou_orgao = empresa_ou_orgao
+        colaborador_atual.instituicao_ensino = instituicao_ensino
+        colaborador_atual.telefone = telefone
+
+        colaborador_salvo = self.repository.update_colaborador(colaborador_atual)
+
+        return ColaboradorResponseDTO(
+            id=colaborador_salvo.id,
+            nome=colaborador_salvo.nome,
+            id_profissional_responsavel=colaborador_salvo.id_profissional_responsavel,
+            is_tecnico=colaborador_salvo.is_tecnico,
+            email=colaborador_salvo.email,
+            cft=colaborador_salvo.cft,
+            uf=colaborador_salvo.uf,
+            cidade=colaborador_salvo.cidade,
+            empresa_ou_orgao=colaborador_salvo.empresa_ou_orgao,
+            telefone=colaborador_salvo.telefone,
+            instituicao_ensino=colaborador_salvo.instituicao_ensino,
+            limite_acesso=colaborador_salvo.limite_acesso,
+            acesso_liberado=colaborador_salvo.acesso_liberado,
+            status="Ativo",
+        )

--- a/backend/src/modules/colaborador/domain/repositories/IColaboradorRepository.py
+++ b/backend/src/modules/colaborador/domain/repositories/IColaboradorRepository.py
@@ -10,6 +10,10 @@ class IColaboradorRepository(ABC):
         pass
 
     @abstractmethod
+    def find_by_id(self, colaborador_id: int) -> Optional[Colaborador]:
+        pass
+
+    @abstractmethod
     def find_all(self) -> List[Colaborador]:
         pass
 
@@ -27,6 +31,10 @@ class IColaboradorRepository(ABC):
 
     @abstractmethod
     def update_tempo_bloqueio(self, supervisor_id: int, tempo_bloqueio: datetime):
+        pass
+
+    @abstractmethod
+    def update_colaborador(self, colaborador: Colaborador) -> Colaborador:
         pass
 
     @abstractmethod

--- a/backend/src/modules/colaborador/infrastructure/repositories/ColaboradorRepository.py
+++ b/backend/src/modules/colaborador/infrastructure/repositories/ColaboradorRepository.py
@@ -48,6 +48,13 @@ class ColaboradorRepository(IColaboradorRepository):
         return Colaborador.model_validate(col_orm)
 
 
+    def find_by_id(self, colaborador_id: int) -> Optional[Colaborador]:
+        col_orm = self.session.query(ColaboradorORM).filter(
+            ColaboradorORM.id == colaborador_id
+        ).first()
+        return Colaborador.model_validate(col_orm) if col_orm else None
+
+
     def find_all(self) -> List[Colaborador]:
         cols_orm = self.session.query(ColaboradorORM).all()
         return [Colaborador.model_validate(col_orm) for col_orm in cols_orm]
@@ -111,6 +118,23 @@ class ColaboradorRepository(IColaboradorRepository):
         col_orm.limite_acesso = limite_acesso
         self.session.commit()
         self.session.refresh(col_orm)
+
+    def update_colaborador(self, colaborador: Colaborador) -> Colaborador:
+        col_orm = self.session.get(ColaboradorORM, colaborador.id)
+
+        if not col_orm:
+            raise ValueError("Colaborador não encontrado")
+
+        col_orm.nome = colaborador.nome
+        col_orm.uf = colaborador.uf
+        col_orm.cidade = colaborador.cidade
+        col_orm.instituicao_ensino = colaborador.instituicao_ensino
+        col_orm.empresa_ou_orgao = colaborador.empresa_ou_orgao
+        col_orm.telefone = colaborador.telefone
+
+        self.session.commit()
+        self.session.refresh(col_orm)
+        return Colaborador.model_validate(col_orm)
 
     def delete(self, colaborador_id: int) -> None:
         col_orm = self.session.query(ColaboradorORM).filter(

--- a/backend/src/modules/supervisor/api/http/supervisor_routes.py
+++ b/backend/src/modules/supervisor/api/http/supervisor_routes.py
@@ -86,6 +86,39 @@ async def listar_supervisores(
 
 
 @router.put(
+    "/me",
+    response_model=SupervisorResponseDTO,
+    summary="Atualizar meu perfil",
+    description="Atualiza apenas o perfil do supervisor autenticado usando o sub do JWT"
+)
+async def atualizar_meu_perfil(
+    update_data: UpdateSupervisorDTO,
+    payload: Annotated[dict, Depends(verify_supervisor_role)],
+    repository = Depends(get_repository),
+    string_validator = Depends(get_string_validator),
+    telefone_validator = Depends(get_telefone_validator),
+):
+    try:
+        user_id_raw = payload.get("sub")
+        if not user_id_raw:
+            raise HTTPException(status_code=401, detail="Token inválido")
+
+        supervisor_id = int(str(user_id_raw))
+        use_case = AtualizarSupervisorUseCase(
+            repository,
+            string_validator,
+            telefone_validator,
+        )
+        return use_case.execute(supervisor_id, update_data)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Erro ao atualizar supervisor: {str(e)}")
+
+
+@router.put(
     "/{supervisor_id}",
     response_model=SupervisorResponseDTO,
     summary="Atualizar Supervisor",

--- a/backend/src/modules/supervisor/api/http/supervisor_routes.py
+++ b/backend/src/modules/supervisor/api/http/supervisor_routes.py
@@ -2,16 +2,18 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from src.shared.infrastructure.db import get_session
-from src.modules.supervisor.domain.entities.supervisor import Supervisor
 from src.modules.supervisor.application.user_case.uc_01 import CriarSupervisorUseCase
+from src.modules.supervisor.application.user_case.uc_08 import AtualizarSupervisorUseCase
 from src.modules.supervisor.application.user_case.ListarSupervisorUseCase import ListarSupervisorUseCase
-from src.modules.supervisor.application.dtos import CreateSupervisorDTO, SupervisorResponseDTO
+from src.modules.supervisor.application.dtos import CreateSupervisorDTO, SupervisorResponseDTO, UpdateSupervisorDTO
 from src.modules.supervisor.infrastructure.repositories.SupervisorRepository import SupervisorRepository
 from src.modules.supervisor.infrastructure.gateway.validador_crea_api import ValidadorCREAApi
 from src.modules.supervisor.infrastructure.security.argon2_hasher import Argon2PasswordHasher
+from src.shared.auth.dependencies import verify_supervisor_role
 from src.shared.validators.email_validator import EmailValidator
 from src.shared.infrastructure.email_unico_validator import EmailUnicoValidator
 from src.shared.validators.string_sem_numero_validator import StringSemNumeroValidator
+from src.shared.validators.telefone_validator import TelefoneValidator
 
 router = APIRouter(tags=["Supervisores"])
 
@@ -29,6 +31,9 @@ def get_email_validator():
 
 def get_string_validator():
     return StringSemNumeroValidator()
+
+def get_telefone_validator():
+    return TelefoneValidator()
 
 def get_email_unico_validator(session: Annotated[Session, Depends(get_session)]):
     return EmailUnicoValidator(session)
@@ -78,4 +83,31 @@ async def listar_supervisores(
         return use_case.execute()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao listar supervisores: {str(e)}")
+
+
+@router.put(
+    "/{supervisor_id}",
+    response_model=SupervisorResponseDTO,
+    summary="Atualizar Supervisor",
+    description="Atualiza os dados de perfil do supervisor com validações de nome, UF, cidade e telefone"
+)
+async def atualizar_supervisor(
+    supervisor_id: int,
+    update_data: UpdateSupervisorDTO,
+    _: Annotated[dict, Depends(verify_supervisor_role)],
+    repository = Depends(get_repository),
+    string_validator = Depends(get_string_validator),
+    telefone_validator = Depends(get_telefone_validator),
+):
+    try:
+        use_case = AtualizarSupervisorUseCase(
+            repository,
+            string_validator,
+            telefone_validator,
+        )
+        return use_case.execute(supervisor_id, update_data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Erro ao atualizar supervisor: {str(e)}")
 

--- a/backend/src/modules/supervisor/application/dtos/__init__.py
+++ b/backend/src/modules/supervisor/application/dtos/__init__.py
@@ -1,4 +1,4 @@
-from src.modules.supervisor.application.dtos.supervisor_dto import CreateSupervisorDTO, SupervisorResponseDTO
+from src.modules.supervisor.application.dtos.supervisor_dto import CreateSupervisorDTO, SupervisorResponseDTO, UpdateSupervisorDTO
 
-__all__ = ["CreateSupervisorDTO", "SupervisorResponseDTO"]
+__all__ = ["CreateSupervisorDTO", "SupervisorResponseDTO", "UpdateSupervisorDTO"]
 

--- a/backend/src/modules/supervisor/application/dtos/supervisor_dto.py
+++ b/backend/src/modules/supervisor/application/dtos/supervisor_dto.py
@@ -14,6 +14,16 @@ class CreateSupervisorDTO(BaseModel):
     senha: str
 
 
+class UpdateSupervisorDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    nome: str
+    uf: str
+    cidade: str
+    empresa_ou_orgao: Optional[str] = None
+    telefone: Optional[str] = None
+
+
 class SupervisorResponseDTO(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     

--- a/backend/src/modules/supervisor/application/user_case/ListarSupervisorUseCase.py
+++ b/backend/src/modules/supervisor/application/user_case/ListarSupervisorUseCase.py
@@ -16,7 +16,9 @@ class ListarSupervisorUseCase:
                 email=supervisor.email,
                 identificador_profissional=supervisor.idendificador_profissional,
                 uf=supervisor.uf,
-                cidade=supervisor.cidade
+                cidade=supervisor.cidade,
+                telefone=supervisor.telefone,
+                empresa=supervisor.empresa_ou_orgao
             )
             for supervisor in supervisores
         ]

--- a/backend/src/modules/supervisor/application/user_case/uc_08.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_08.py
@@ -24,27 +24,29 @@ class AtualizarSupervisorUseCase:
             raise ValueError("Supervisor não encontrado")
 
         nome_formatado = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.nome).title()
-
         if not self.string_sem_numero_validator.validar_string_sem_numero(nome_formatado):
             raise ValueError("Nome deve incluir apenas letras")
-
-        cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.cidade).title()
-
-        if not self.string_sem_numero_validator.validar_string_sem_numero(cidade_formatada):
-            raise ValueError("Cidade deve incluir apenas letras")
 
         if not UFEnum.is_valid(update_data.uf):
             raise ValueError("UF inválida")
 
-        empresa_ou_orgao = update_data.empresa_ou_orgao.strip() if update_data.empresa_ou_orgao else None
+        cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.cidade).title()
+        if not self.string_sem_numero_validator.validar_string_sem_numero(cidade_formatada):
+            raise ValueError("Cidade deve incluir apenas letras")
 
-        telefone = None
-        if update_data.telefone:
-            telefone = update_data.telefone.strip()
-            if telefone and not self.telefone_validator.validar_telefone(telefone):
-                raise ValueError("Telefone inválido")
-            if telefone:
-                telefone = self.telefone_validator.formatar_telefone(telefone)
+        empresa_ou_orgao = supervisor_atual.empresa_ou_orgao
+        if update_data.empresa_ou_orgao is not None:
+            empresa_ou_orgao = update_data.empresa_ou_orgao.strip() or None
+
+        telefone = supervisor_atual.telefone
+        if update_data.telefone is not None:
+            telefone_limpo = update_data.telefone.strip()
+            if telefone_limpo:
+                if not self.telefone_validator.validar_telefone(telefone_limpo):
+                    raise ValueError("Telefone inválido")
+                telefone = self.telefone_validator.formatar_telefone(telefone_limpo)
+            else:
+                telefone = None
 
         supervisor_atual.name = nome_formatado
         supervisor_atual.uf = update_data.uf

--- a/backend/src/modules/supervisor/application/user_case/uc_08.py
+++ b/backend/src/modules/supervisor/application/user_case/uc_08.py
@@ -1,0 +1,66 @@
+from src.modules.supervisor.application.dtos import SupervisorResponseDTO, UpdateSupervisorDTO
+from src.modules.supervisor.domain.repositories.ISupervisorRepository import ISupervisorRepository
+from src.shared.domain.interfaces.i_string_sem_numeros_validator import IStringSemNumeroValidador
+from src.shared.domain.interfaces.i_telefone_validator import ITelefoneValidator
+from src.shared.enums.uf_enum import UFEnum
+
+
+class AtualizarSupervisorUseCase:
+
+    def __init__(
+        self,
+        repository: ISupervisorRepository,
+        string_sem_numero_validator: IStringSemNumeroValidador,
+        telefone_validator: ITelefoneValidator,
+    ):
+        self.repository = repository
+        self.string_sem_numero_validator = string_sem_numero_validator
+        self.telefone_validator = telefone_validator
+
+    def execute(self, supervisor_id: int, update_data: UpdateSupervisorDTO) -> SupervisorResponseDTO:
+        supervisor_atual = self.repository.find_by_id(supervisor_id)
+
+        if supervisor_atual is None:
+            raise ValueError("Supervisor não encontrado")
+
+        nome_formatado = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.nome).title()
+
+        if not self.string_sem_numero_validator.validar_string_sem_numero(nome_formatado):
+            raise ValueError("Nome deve incluir apenas letras")
+
+        cidade_formatada = self.string_sem_numero_validator.formatar_string_sem_numero(update_data.cidade).title()
+
+        if not self.string_sem_numero_validator.validar_string_sem_numero(cidade_formatada):
+            raise ValueError("Cidade deve incluir apenas letras")
+
+        if not UFEnum.is_valid(update_data.uf):
+            raise ValueError("UF inválida")
+
+        empresa_ou_orgao = update_data.empresa_ou_orgao.strip() if update_data.empresa_ou_orgao else None
+
+        telefone = None
+        if update_data.telefone:
+            telefone = update_data.telefone.strip()
+            if telefone and not self.telefone_validator.validar_telefone(telefone):
+                raise ValueError("Telefone inválido")
+            if telefone:
+                telefone = self.telefone_validator.formatar_telefone(telefone)
+
+        supervisor_atual.name = nome_formatado
+        supervisor_atual.uf = update_data.uf
+        supervisor_atual.cidade = cidade_formatada
+        supervisor_atual.empresa_ou_orgao = empresa_ou_orgao
+        supervisor_atual.telefone = telefone
+
+        supervisor_salvo = self.repository.update_supervisor(supervisor_atual)
+
+        return SupervisorResponseDTO(
+            id=supervisor_salvo.id,
+            nome=supervisor_salvo.name,
+            email=supervisor_salvo.email,
+            identificador_profissional=supervisor_salvo.idendificador_profissional,
+            uf=supervisor_salvo.uf,
+            cidade=supervisor_salvo.cidade,
+            telefone=supervisor_salvo.telefone,
+            empresa=supervisor_salvo.empresa_ou_orgao,
+        )

--- a/backend/src/modules/supervisor/domain/entities/supervisor.py
+++ b/backend/src/modules/supervisor/domain/entities/supervisor.py
@@ -23,6 +23,10 @@ class SupervisorORM(Base):
     cidade = Column(String(50), nullable=False)
     
     email = Column(String(150), unique=True, nullable=False)
+
+    telefone = Column(String(20), nullable=True)
+
+    empresa_ou_orgao = Column(String(255), nullable=True)
     
     password = Column(String(255), nullable=False)
 
@@ -39,6 +43,8 @@ class Supervisor(BaseModel):
     uf: str
     cidade: str
     email: str
+    empresa_ou_orgao: Optional[str] = None
+    telefone: Optional[str] = None
     password: str
     tentativas_falhas: int = 0
     limite_de_bloqueio: Optional[datetime] = None

--- a/backend/src/modules/supervisor/domain/repositories/ISupervisorRepository.py
+++ b/backend/src/modules/supervisor/domain/repositories/ISupervisorRepository.py
@@ -32,3 +32,7 @@ class ISupervisorRepository(ABC):
     @abstractmethod
     def update_tempo_bloqueio(self, supervisor_id: int, tempo_bloqueio: datetime):
         pass
+
+    @abstractmethod
+    def update_supervisor(self, novo_supervisor: Supervisor) -> Supervisor:
+        pass

--- a/backend/src/modules/supervisor/infrastructure/repositories/SupervisorRepository.py
+++ b/backend/src/modules/supervisor/infrastructure/repositories/SupervisorRepository.py
@@ -85,4 +85,35 @@ class SupervisorRepository(ISupervisorRepository):
         supervisor_orm.limite_de_bloqueio = tempo_bloqueio
         self.session.commit()
         self.session.refresh(supervisor_orm)
+
+    def update_supervisor(self, novo_supervisor: Supervisor) -> Supervisor:
+        sup_orm = self.session.get(SupervisorORM, novo_supervisor.id)
+
+        if not sup_orm: 
+            raise ValueError("Supervisor não encontrado")
+        
+        sup_orm.name = novo_supervisor.name
+        sup_orm.cidade = novo_supervisor.cidade
+        sup_orm.empresa_ou_orgao = novo_supervisor.empresa_ou_orgao
+        sup_orm.telefone = novo_supervisor.telefone
+        sup_orm.uf = novo_supervisor.uf
+
+        try:
+            self.session.commit()
+        except IntegrityError as e:
+            self.session.rollback()
+            error_msg = str(e).lower()
+
+            campo = None
+            if "supervisor_email_key" in error_msg:
+                campo = "Email"
+            elif "supervisor_idendificador_profissional_key" in error_msg:
+                campo = "Identificador profissional"
+
+            if campo:
+                raise ValueError(f"{campo} já cadastrado no sistema")
+            raise
+
+        self.session.refresh(sup_orm)
+        return Supervisor.model_validate(sup_orm)
         


### PR DESCRIPTION
# Atualizacao de Perfil com JWT - Supervisor e Colaborador

## Resumo
Implementacao dos endpoints de atualizacao de perfil do supervisor e do colaborador usando o JWT como fonte de identidade. O fluxo agora evita enviar `id` pelo front para a operacao de "me" e permite update parcial nos campos opcionais, mantendo validacao no backend.

## Funcionalidades

### 1. Atualizacao de perfil autenticado
- Criado `PUT /api/supervisores/me` para atualizar o supervisor logado.
- Criado `PUT /api/colaboradores/me` para atualizar o colaborador logado.
- O identificador do usuario vem do `sub` do JWT.
- O front nao precisa enviar `id` para salvar o proprio perfil.

### 2. Update parcial no backend
- `nome`, `uf` e `cidade` continuam obrigatorios no supervisor.
- Campos adicionais como `empresa_ou_orgao` e `telefone` seguem opcionais.
- No colaborador, os campos opcionais continuam preservados quando nao sao enviados.
- O use case atualiza apenas o que faz sentido para o contrato de cada rota.

### 3. Protecao de autorizacao
- O backend valida o token antes de permitir a alteracao.
- O update de perfil nao depende de um `id` informado pelo cliente.
- Isso reduz o risco de um usuario atualizar dados de outro.

## Endpoints

- `PUT /api/supervisores/me` - Atualiza o perfil do supervisor autenticado.
- `PUT /api/colaboradores/me` - Atualiza o perfil do colaborador autenticado.
- `PUT /api/supervisores/{supervisor_id}` - Mantido para fluxo administrativo, se necessario.

## DTOs

- `UpdateSupervisorDTO`: nome, uf, cidade, empresa_ou_orgao, telefone
- `UpdateColaboradorDTO`: nome, uf, cidade, empresa_ou_orgao, telefone, instituicao_ensino
- `SupervisorResponseDTO`: id, nome, identificador_profissional, uf, cidade, email, telefone, empresa
- `ColaboradorResponseDTO`: id, nome, id_profissional_responsavel, is_tecnico, email, cft, uf, cidade, empresa_ou_orgao, telefone, instituicao_ensino, limite_acesso, acesso_liberado, status

## Fluxo / Lógica

1. O front envia o `access token` no header `Authorization: Bearer <token>`.
2. A rota `me` decodifica o JWT e extrai o `sub` do usuario.
3. O backend busca o registro correto no banco usando esse id.
4. O use case valida apenas os campos recebidos.
5. O repositório salva a entidade atualizada e retorna a resposta.

## Instrucoes para o Front

### Como salvar o proprio perfil
- Use `PUT /api/supervisores/me` para supervisor e `PUT /api/colaboradores/me` para colaborador.
- Envie o token de acesso em `Authorization: Bearer <token>`.
- Nao envie `id` do usuario no payload da rota `me`.
- Envie apenas os campos permitidos pela tela.

### Exemplo de payload para supervisor
```json
{
  "nome": "Joao Silva",
  "uf": "CE",
  "cidade": "Fortaleza",
  "empresa_ou_orgao": "DNIT",
  "telefone": "(85) 99999-9999"
}
```

### Exemplo de payload para colaborador
```json
{
  "nome": "Maria Souza",
  "uf": "CE",
  "cidade": "Fortaleza",
  "empresa_ou_orgao": "Prefeitura",
  "telefone": "(85) 98888-7777",
  "instituicao_ensino": "IFCE"
}
```

### Regras para a tela
- O botao de salvar deve usar o token salvo no login.
- O front deve tratar erro 401 como token invalido ou expirado.
- O front deve tratar erro 403 como usuario sem permissao.
- Para supervisor, `nome`, `uf` e `cidade` devem ser preenchidos antes do submit.
- Para colaborador, respeitar os campos do formulario de perfil sem depender de `id` manual.

## Extras

- O fluxo ficou mais seguro porque o id de alteracao veio do JWT.
- A documentacao do front agora pode seguir o contrato das rotas `me`.
- O endpoint administrativo por id continua disponivel para uso interno, se necessario.