### PR TITLE
feat(US_09): implementação backend do upload de multiplas imagens

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ alembic>=1.13.0
 redis>=5.0.0
 minio>=7.2.8
 python-multipart>=0.0.9
+Pillow>=10.0.0

--- a/backend/src/modules/fotos/api/http/fotos_routes.py
+++ b/backend/src/modules/fotos/api/http/fotos_routes.py
@@ -1,12 +1,22 @@
 import os
+from typing import List
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import JSONResponse
 
-from src.modules.fotos.application.dtos.foto_dto import FotoDeleteResponseDTO, FotoUploadResponseDTO
+from src.modules.fotos.application.dtos.foto_dto import (
+    FotoDeleteResponseDTO,
+    FotoUploadResponseDTO,
+    ImagemUploadInputDTO,
+    ProcessamentoFotosResponseDTO,
+)
+from src.modules.fotos.application.use_case.uc_09 import Uc09UploadMultiplasImagensUseCase
+from src.modules.fotos.infrastructure.repositories.foto_repository import FotoRepository
 from src.modules.fotos.infrastructure.services.minio_adapter import MinioAdapter
 from src.modules.fotos.infrastructure.services.minio_client import ensure_bucket_exists, get_minio_client
-from src.shared.auth.dependencies import verify_supervisor_role
+from src.shared.auth.dependencies import verify_any_user, verify_supervisor_role
+from src.shared.infrastructure.db import get_session
 
 router = APIRouter(tags=["Fotos"])
 
@@ -15,6 +25,74 @@ def get_foto_storage() -> MinioAdapter:
     bucket_name = os.getenv("MINIO_BUCKET", "smp-fotos")
     ensure_bucket_exists(bucket_name)
     return MinioAdapter(get_minio_client(), bucket_name)
+
+
+def get_foto_repository(session=Depends(get_session)) -> FotoRepository:
+    return FotoRepository(session)
+
+
+def get_uc09(
+    foto_repository: FotoRepository = Depends(get_foto_repository),
+    foto_storage: MinioAdapter = Depends(get_foto_storage),
+) -> Uc09UploadMultiplasImagensUseCase:
+    return Uc09UploadMultiplasImagensUseCase(foto_repository=foto_repository, foto_storage=foto_storage)
+
+
+@router.post(
+    "/upload-multiplas",
+    response_model=ProcessamentoFotosResponseDTO,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload múltiplo de imagens",
+    description="Recebe várias imagens, extrai geolocalização, envia para o MinIO e persiste no banco",
+    openapi_extra={
+        "requestBody": {
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "files": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "format": "binary",
+                                },
+                            }
+                        },
+                        "required": ["files"],
+                    }
+                }
+            }
+        }
+    },
+)
+async def upload_multiplas_imagens(
+    files: List[UploadFile] = File(..., description="Arquivos de imagem no campo files"),
+    _: dict = Depends(verify_any_user),
+    use_case: Uc09UploadMultiplasImagensUseCase = Depends(get_uc09),
+):
+    if not files:
+        raise HTTPException(status_code=400, detail="Nenhum arquivo foi enviado")
+
+    arquivos = [
+        ImagemUploadInputDTO(
+            filename=file.filename or f"imagem-{index + 1}",
+            content_type=file.content_type,
+            content=await file.read(),
+        )
+        for index, file in enumerate(files)
+    ]
+
+    resultado = await use_case.execute(arquivos)
+
+    if resultado.success and resultado.failed:
+        status_code = status.HTTP_207_MULTI_STATUS
+    elif resultado.success:
+        status_code = status.HTTP_201_CREATED
+    else:
+        status_code = status.HTTP_400_BAD_REQUEST
+
+    return JSONResponse(status_code=status_code, content=resultado.model_dump(mode="json"))
 
 
 @router.post(

--- a/backend/src/modules/fotos/application/dtos/foto_dto.py
+++ b/backend/src/modules/fotos/application/dtos/foto_dto.py
@@ -15,3 +15,35 @@ class FotoDeleteResponseDTO(BaseModel):
 
     caminho_arquivo: str
     removido: bool = True
+
+
+class ImagemUploadInputDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    filename: str
+    content_type: str | None = None
+    content: bytes
+
+
+class FotoUploadSucessoDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int
+    latitude: float
+    longitude: float
+    caminho_arquivo: str
+
+
+class FotoUploadFalhaDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    filename: str
+    reason: str
+    image_url: str | None = None
+
+
+class ProcessamentoFotosResponseDTO(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    success: list[FotoUploadSucessoDTO]
+    failed: list[FotoUploadFalhaDTO]

--- a/backend/src/modules/fotos/application/use_case/uc_09.py
+++ b/backend/src/modules/fotos/application/use_case/uc_09.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from io import BytesIO
+from uuid import uuid4
+
+from PIL import ExifTags, Image, UnidentifiedImageError
+
+from src.modules.fotos.application.dtos.foto_dto import (
+    FotoUploadFalhaDTO,
+    FotoUploadSucessoDTO,
+    ImagemUploadInputDTO,
+    ProcessamentoFotosResponseDTO,
+)
+from src.modules.fotos.domain.entities.fotos import Foto
+from src.modules.fotos.domain.repositories.i_foto_repository import IFotoRepository
+from src.modules.fotos.domain.repositories.i_foto_storage import IFotoStorage
+
+
+@dataclass(frozen=True)
+class CoordenadasExif:
+    latitude: float
+    longitude: float
+
+
+class Uc09UploadMultiplasImagensUseCase:
+    def __init__(self, foto_repository: IFotoRepository, foto_storage: IFotoStorage):
+        self.foto_repository = foto_repository
+        self.foto_storage = foto_storage
+
+    async def execute(self, files: list[ImagemUploadInputDTO]) -> ProcessamentoFotosResponseDTO:
+        success: list[FotoUploadSucessoDTO] = []
+        failed: list[FotoUploadFalhaDTO] = []
+
+        for file in files:
+            uploaded_image_url: str | None = None
+
+            if not file.content:
+                failed.append(
+                    FotoUploadFalhaDTO(
+                        filename=file.filename,
+                        reason="Arquivo vazio",
+                        image_url=None,
+                    )
+                )
+                continue
+
+            try:
+                # 1. SEMPRE fazer upload da imagem primeiro
+                extensao = os.path.splitext(file.filename)[1].lower()
+                nome_arquivo = f"{uuid4().hex}{extensao}"
+                content_type = file.content_type or "application/octet-stream"
+
+                caminho_arquivo = self.foto_storage.save(
+                    conteudo_arquivo=file.content,
+                    nome_arquivo=nome_arquivo,
+                    content_type=content_type,
+                )
+                uploaded_image_url = caminho_arquivo
+
+                # 2. Tentar extrair coordenadas
+                coordenadas = self._extrair_coordenadas(file.content)
+                if coordenadas is None:
+                    # Imagem foi salva, mas sem geolocalização
+                    failed.append(
+                        FotoUploadFalhaDTO(
+                            filename=file.filename,
+                            reason="Geolocalização não encontrada",
+                            image_url=uploaded_image_url,
+                        )
+                    )
+                    continue
+
+                # 3. Salvar no banco de dados com coordenadas
+                foto = Foto(
+                    nome_original_arquivo=file.filename,
+                    nome_aquivo=nome_arquivo,
+                    caminho_arquivo=caminho_arquivo,
+                    latitude=coordenadas.latitude,
+                    longitude=coordenadas.longitude,
+                    tipo_arquivo=content_type,
+                )
+
+                foto_salva = self.foto_repository.save(foto)
+                success.append(
+                    FotoUploadSucessoDTO(
+                        id=foto_salva.id if foto_salva.id is not None else 0,
+                        latitude=foto_salva.latitude if foto_salva.latitude is not None else coordenadas.latitude,
+                        longitude=foto_salva.longitude if foto_salva.longitude is not None else coordenadas.longitude,
+                        caminho_arquivo=foto_salva.caminho_arquivo,
+                    )
+                )
+            except Exception as exc:
+                failed.append(
+                    FotoUploadFalhaDTO(
+                        filename=file.filename,
+                        reason=str(exc) or "Falha ao processar imagem",
+                        image_url=uploaded_image_url,
+                    )
+                )
+
+        return ProcessamentoFotosResponseDTO(success=success, failed=failed)
+
+    def _extrair_coordenadas(self, conteudo_arquivo: bytes) -> CoordenadasExif | None:
+        try:
+            imagem = Image.open(BytesIO(conteudo_arquivo))
+        except UnidentifiedImageError:
+            return None
+
+        exif = imagem.getexif()
+        if not exif:
+            return None
+
+        gps_tag = next((tag for tag, name in ExifTags.TAGS.items() if name == "GPSInfo"), None)
+        if gps_tag is None:
+            return None
+
+        gps_ifd = exif.get_ifd(gps_tag)
+        if not gps_ifd:
+            return None
+
+        def _buscar_tag(nome: str) -> int | None:
+            return next((tag for tag, tag_nome in ExifTags.GPSTAGS.items() if tag_nome == nome), None)
+
+        lat_ref_tag = _buscar_tag("GPSLatitudeRef")
+        lat_tag = _buscar_tag("GPSLatitude")
+        lon_ref_tag = _buscar_tag("GPSLongitudeRef")
+        lon_tag = _buscar_tag("GPSLongitude")
+
+        if None in {lat_ref_tag, lat_tag, lon_ref_tag, lon_tag}:
+            return None
+
+        latitude_raw = gps_ifd.get(lat_tag)
+        longitude_raw = gps_ifd.get(lon_tag)
+        latitude_ref = gps_ifd.get(lat_ref_tag)
+        longitude_ref = gps_ifd.get(lon_ref_tag)
+
+        # Validar que os valores existem
+        if latitude_raw is None or longitude_raw is None or latitude_ref is None or longitude_ref is None:
+            return None
+
+        try:
+            latitude = self._converter_gps_para_decimal(latitude_raw)
+            longitude = self._converter_gps_para_decimal(longitude_raw)
+        except (TypeError, ValueError, IndexError):
+            return None
+
+        latitude_ref_str = latitude_ref.decode() if isinstance(latitude_ref, bytes) else str(latitude_ref)
+        longitude_ref_str = longitude_ref.decode() if isinstance(longitude_ref, bytes) else str(longitude_ref)
+
+        if latitude_ref_str.upper() == "S":
+            latitude *= -1
+        if longitude_ref_str.upper() == "W":
+            longitude *= -1
+
+        return CoordenadasExif(latitude=latitude, longitude=longitude)
+
+    def _converter_gps_para_decimal(self, valor_gps) -> float:
+        """
+        Converte valor GPS de múltiplos formatos para decimal.
+        PIL retorna GPS como tupla de Fraction ou valores numéricos.
+        """
+        try:
+            # Se for tupla/lista, desempacotar como (graus, minutos, segundos)
+            if isinstance(valor_gps, (tuple, list)):
+                if len(valor_gps) >= 3:
+                    graus = float(valor_gps[0])
+                    minutos = float(valor_gps[1])
+                    segundos = float(valor_gps[2])
+                    return graus + (minutos / 60.0) + (segundos / 3600.0)
+                else:
+                    raise ValueError(f"GPS inválido: esperava 3 valores, recebeu {len(valor_gps)}")
+            
+            # Se for um Fraction object do PIL
+            elif hasattr(valor_gps, 'numerator') and hasattr(valor_gps, 'denominator'):
+                return float(valor_gps)
+            
+            # Se for um número simples
+            else:
+                return float(valor_gps)
+        
+        except (TypeError, ValueError, IndexError, ZeroDivisionError) as e:
+            raise ValueError(f"Erro ao converter GPS '{valor_gps}': {e}")

--- a/backend/src/modules/fotos/domain/entities/fotos.py
+++ b/backend/src/modules/fotos/domain/entities/fotos.py
@@ -1,39 +1,39 @@
-from sqlalchemy import Column, String, Enum
-from src.shared.enums.uf_enum import UFEnum
-from sqlalchemy import Column, Integer, Boolean
-from sqlalchemy import ForeignKey
-from sqlalchemy import DateTime
-from src.shared.infrastructure.db import Base
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import Column, DateTime, Float, Integer, String
+
+from src.shared.infrastructure.db import Base
+
 
 class fotosORM(Base):
     __tablename__ = "fotos"
-    
+
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-
     nome_original_arquivo = Column(String, nullable=False)
-
     nome_aquivo = Column(String, unique=True, nullable=False)
-
     caminho_arquivo = Column(String, nullable=False)
-
+    latitude = Column(Float, nullable=True)
+    longitude = Column(Float, nullable=True)
     tipo_arquivo = Column(String, nullable=False)
-
     criado_em = Column(
-        DateTime(timezone=True), 
-        nullable=False, 
-        default=lambda: datetime.now(timezone.utc)
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
     )
 
-class Colaborador(BaseModel):
-    model_config = {"from_attributes": True}
-    
-    
-    id: int
+
+class Foto(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int | None = None
     nome_original_arquivo: str
     nome_aquivo: str
     caminho_arquivo: str
+    latitude: float | None = None
+    longitude: float | None = None
     tipo_arquivo: str
-    criado_em: datetime
+    criado_em: datetime | None = None
+
+
+Colaborador = Foto

--- a/backend/src/modules/fotos/domain/repositories/i_foto_repository.py
+++ b/backend/src/modules/fotos/domain/repositories/i_foto_repository.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from src.modules.fotos.domain.entities.fotos import Foto
+
+
+class IFotoRepository(ABC):
+    @abstractmethod
+    def save(self, foto: Foto) -> Foto:
+        raise NotImplementedError

--- a/backend/src/modules/fotos/domain/repositories/i_foto_storage.py
+++ b/backend/src/modules/fotos/domain/repositories/i_foto_storage.py
@@ -4,7 +4,7 @@ class IFotoStorage(ABC):
 
     "Salva e retorna o URL da foto"
     @abstractmethod
-    def save(self, conteudo_arquivo: bytes, nome_arquivo: str) -> str:
+    def save(self, conteudo_arquivo: bytes, nome_arquivo: str, content_type: str | None = None) -> str:
         pass
 
     @abstractmethod

--- a/backend/src/modules/fotos/infrastructure/repositories/foto_repository.py
+++ b/backend/src/modules/fotos/infrastructure/repositories/foto_repository.py
@@ -1,0 +1,30 @@
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.modules.fotos.domain.entities.fotos import Foto, fotosORM
+from src.modules.fotos.domain.repositories.i_foto_repository import IFotoRepository
+
+
+class FotoRepository(IFotoRepository):
+	def __init__(self, session: Session):
+		self.session = session
+
+	def save(self, foto: Foto) -> Foto:
+		foto_orm = fotosORM(
+			nome_original_arquivo=foto.nome_original_arquivo,
+			nome_aquivo=foto.nome_aquivo,
+			caminho_arquivo=foto.caminho_arquivo,
+			latitude=foto.latitude,
+			longitude=foto.longitude,
+			tipo_arquivo=foto.tipo_arquivo,
+		)
+
+		self.session.add(foto_orm)
+		try:
+			self.session.commit()
+		except IntegrityError as exc:
+			self.session.rollback()
+			raise ValueError("Erro ao salvar a foto no banco de dados") from exc
+
+		self.session.refresh(foto_orm)
+		return Foto.model_validate(foto_orm)


### PR DESCRIPTION
## Descrição
Ajuste no fluxo de upload de imagens para salvar a foto no MinIO mesmo quando a geolocalização não for encontrada, retornando a URL do objeto no erro para facilitar a exibição no front. Também foi corrigido o parser de EXIF/GPS para lidar corretamente com os formatos retornados pelo PIL.

## Funcionalidades

### 1. Upload sempre salvo no MinIO
- A imagem é enviada ao MinIO antes da validação de geolocalização
- Mesmo com erro de GPS, a imagem continua disponível para o front
- O retorno de erro passa a incluir `image_url`

### 2. Leitura robusta de EXIF/GPS
- Uso correto de `get_ifd()` para ler o bloco GPS do EXIF
- Conversão dos valores GPS para decimal com suporte a diferentes formatos do PIL
- Tratamento de casos inválidos sem quebrar o processamento em lote

### 3. Resposta menor no JSON
- Substituição do envio de `image_base64` por `image_url`
- Redução do tamanho da resposta da API
- Melhor aproveitamento no front para identificar fotos com falha

## Endpoints

- `POST /api/fotos/upload-multiplas` - Upload múltiplo de imagens com retorno de sucesso e falhas
- `POST /api/fotos/` - Upload individual de foto no MinIO
- `DELETE /api/fotos/{caminho_arquivo}` - Remoção de foto do MinIO

## DTOs

- `ImagemUploadInputDTO`: filename, content_type, content
- `FotoUploadSucessoDTO`: id, latitude, longitude, caminho_arquivo
- `FotoUploadFalhaDTO`: filename, reason, image_url
- `ProcessamentoFotosResponseDTO`: success, failed

## Fluxo / Lógica

1. O backend recebe as imagens no upload múltiplo
2. Cada imagem é salva no MinIO imediatamente
3. O sistema tenta extrair a geolocalização do EXIF
4. Se houver GPS, a foto é persistida no banco como sucesso
5. Se não houver GPS, a foto continua salva e retorna como falha com `image_url`
6. O front pode exibir a imagem mesmo quando a geolocalização falhar

## Tecnologias Utilizadas

- FastAPI
- PIL/Pillow
- MinIO
- Pydantic
- Python

## Proximos Passos

- [ ] Avaliar se o front deve consumir URL pública, assinada ou endpoint de download
- [ ] Padronizar a exibição das imagens com falha de geolocalização no frontend
- [ ] Adicionar testes para fotos com EXIF válido e inválido

## Extras

- Correção de bug no parser de GPS do EXIF
- Redução do tamanho da resposta JSON
- Melhor suporte para depuração e validação visual no front