### PR TITLE
feat(US_11): implementação do de retorno de fotos com geo-loc e sem

### DIFF
--- a/backend/setup-minio.sh
+++ b/backend/setup-minio.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script para configurar MinIO com bucket público
+
+echo "Aguardando MinIO iniciar..."
+sleep 15
+
+echo "Configurando MinIO..."
+
+# Configurar alias
+/usr/bin/mc alias set minio_local http://localhost:9000 minioadmin minioadmin
+
+# Remover bucket antigo se existir (opcional)
+# /usr/bin/mc rb minio_local/smp-fotos --force
+
+# Criar bucket se não existir
+/usr/bin/mc mb minio_local/smp-fotos --ignore-existing
+
+# Tornar bucket público (leitura e escrita anônima)
+/usr/bin/mc anonymous set public minio_local/smp-fotos
+
+# Verificar configuração
+/usr/bin/mc anonymous list minio_local/smp-fotos
+
+echo "✅ MinIO bucket 'smp-fotos' configurado como público!"

--- a/backend/src/modules/fotos/application/use_case/uc_09.py
+++ b/backend/src/modules/fotos/application/use_case/uc_09.py
@@ -25,6 +25,11 @@ class CoordenadasExif:
 
 
 class Uc09UploadMultiplasImagensUseCase:
+    # Formatos permitidos
+    EXTENSOES_PERMITIDAS = {".jpg", ".jpeg", ".png", ".tiff", ".tif"}
+    # Tamanho máximo: 50 MB
+    TAMANHO_MAXIMO_MB = 50
+    TAMANHO_MAXIMO_BYTES = TAMANHO_MAXIMO_MB * 1024 * 1024
     def __init__(self, foto_repository: IFotoRepository, foto_storage: IFotoStorage):
         self.foto_repository = foto_repository
         self.foto_storage = foto_storage
@@ -46,6 +51,18 @@ class Uc09UploadMultiplasImagensUseCase:
                 )
                 continue
 
+            # Validar formato e tamanho
+            erro_validacao = self._validar_arquivo(file.filename, file.content)
+            if erro_validacao:
+                failed.append(
+                    FotoUploadFalhaDTO(
+                        filename=file.filename,
+                        reason=erro_validacao,
+                        image_url=None,
+                    )
+                )
+                continue
+
             try:
                 # 1. SEMPRE fazer upload da imagem primeiro
                 extensao = os.path.splitext(file.filename)[1].lower()
@@ -62,15 +79,8 @@ class Uc09UploadMultiplasImagensUseCase:
                 # 2. Tentar extrair coordenadas
                 coordenadas = self._extrair_coordenadas(file.content)
                 if coordenadas is None:
-                    # Imagem foi salva, mas sem geolocalização
-                    failed.append(
-                        FotoUploadFalhaDTO(
-                            filename=file.filename,
-                            reason="Geolocalização não encontrada",
-                            image_url=uploaded_image_url,
-                        )
-                    )
-                    continue
+                    # Se não encontrar geolocalização, usar valores padrão (0.0)
+                    coordenadas = CoordenadasExif(latitude=0.0, longitude=0.0)
 
                 # 3. Salvar no banco de dados com coordenadas
                 foto = Foto(
@@ -83,12 +93,18 @@ class Uc09UploadMultiplasImagensUseCase:
                 )
 
                 foto_salva = self.foto_repository.save(foto)
+                
+                # 4. Gerar presigned URL para retorno seguro
+                presigned_url = self.foto_storage.get_presigned_url(
+                    caminho_arquivo=foto_salva.caminho_arquivo
+                )
+                
                 success.append(
                     FotoUploadSucessoDTO(
                         id=foto_salva.id if foto_salva.id is not None else 0,
                         latitude=foto_salva.latitude if foto_salva.latitude is not None else coordenadas.latitude,
                         longitude=foto_salva.longitude if foto_salva.longitude is not None else coordenadas.longitude,
-                        caminho_arquivo=foto_salva.caminho_arquivo,
+                        caminho_arquivo=presigned_url,
                     )
                 )
             except Exception as exc:
@@ -101,6 +117,25 @@ class Uc09UploadMultiplasImagensUseCase:
                 )
 
         return ProcessamentoFotosResponseDTO(success=success, failed=failed)
+
+    def _validar_arquivo(self, filename: str, conteudo: bytes) -> str | None:
+        """
+        Valida o arquivo verificando formato e tamanho.
+        Retorna mensagem de erro se inválido, None se válido.
+        """
+        # Verificar extensão
+        extensao = os.path.splitext(filename)[1].lower()
+        if extensao not in self.EXTENSOES_PERMITIDAS:
+            formatos_permitidos = ", ".join(self.EXTENSOES_PERMITIDAS)
+            return f"Formato inválido. Formatos permitidos: {formatos_permitidos}"
+        
+        # Verificar tamanho
+        tamanho_bytes = len(conteudo)
+        if tamanho_bytes > self.TAMANHO_MAXIMO_BYTES:
+            tamanho_mb = tamanho_bytes / (1024 * 1024)
+            return f"Arquivo muito grande ({tamanho_mb:.2f} MB). Tamanho máximo: {self.TAMANHO_MAXIMO_MB} MB"
+        
+        return None
 
     def _extrair_coordenadas(self, conteudo_arquivo: bytes) -> CoordenadasExif | None:
         try:

--- a/backend/src/modules/fotos/domain/repositories/i_foto_storage.py
+++ b/backend/src/modules/fotos/domain/repositories/i_foto_storage.py
@@ -10,3 +10,8 @@ class IFotoStorage(ABC):
     @abstractmethod
     def delete(self, caminho_arquivo: str) -> bool:
         pass
+
+    @abstractmethod
+    def get_presigned_url(self, caminho_arquivo: str, expira_em_segundos: int = 3600) -> str:
+        """Gera uma URL assinada (presigned) para acesso temporário ao arquivo"""
+        pass

--- a/backend/src/modules/fotos/infrastructure/services/minio_adapter.py
+++ b/backend/src/modules/fotos/infrastructure/services/minio_adapter.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 from src.modules.fotos.domain.repositories.i_foto_storage import IFotoStorage
 
+
 class MinioAdapter(IFotoStorage):
     def __init__(self, client, bucket_name: str):
         self.client = client
@@ -25,3 +26,9 @@ class MinioAdapter(IFotoStorage):
             return True
         except Exception:
             return False
+
+    def get_presigned_url(self, caminho_arquivo: str, expira_em_segundos: int = 900) -> str:
+        """Retorna URL pública do arquivo no MinIO (bucket público)"""
+        # Como é desenvolvimento/teste, retornar URL pública simples
+        # O caminho_arquivo já vem como "bucket/arquivo.jpg"
+        return f"http://localhost:9000/{caminho_arquivo}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     container_name: smp_minio
     env_file:
       - ./backend/.env
+    environment:
+      MINIO_SERVER_URL: "http://localhost:9000"
+      MINIO_BROWSER_REDIRECT_URL: "http://localhost:9001"
     command: server /data --console-address ":9001"
     ports:
       - "9000:9000"
@@ -34,6 +37,20 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  minio_setup:
+    image: minio/mc:latest
+    container_name: smp_minio_setup
+    depends_on:
+      min_io:
+        condition: service_healthy
+    volumes:
+      - ./backend/setup-minio.sh:/setup-minio.sh
+    networks:
+      - smp_network
+    entrypoint: /bin/bash
+    command: /setup-minio.sh
+    restart: "no"
 
   postgres:
     image: postgres:15-alpine


### PR DESCRIPTION
## Descrição
Implementação completa do sistema de upload, validação e download de fotos integrado com MinIO. Sistema valida formatos de arquivo (JPG, PNG, TIFF) e tamanho máximo (50 MB), com retorno de URLs públicas para acesso direto.

## Funcionalidades

### 1. Validação de Arquivos
- Verificação de formato: JPG, JPEG, PNG, TIFF, TIF
- Tamanho máximo por arquivo: 50 MB
- Mensagens de erro descritivas

### 2. Upload e Armazenamento
- Upload múltiplo de fotos
- Armazenamento no MinIO com nomes únicos (UUID)
- Extração automática de geolocalização (EXIF)
- Fallback para coordenadas padrão (0.0, 0.0) se não encontrada

### 3. Download e Acesso Público
- URLs públicas para acesso direto das fotos
- Bucket configurado como público automaticamente
- Suporte a acesso sem credenciais

## Endpoints

- `POST /upload-multiplas` - Upload de múltiplas fotos (return 201, 207 ou 400)

## DTOs

- `ImagemUploadInputDTO`: filename, content_type, content
- `FotoUploadSucessoDTO`: id, latitude, longitude, caminho_arquivo (URL pública)
- `FotoUploadFalhaDTO`: filename, reason, image_url
- `ProcessamentoFotosResponseDTO`: success[], failed[]

## Fluxo de Upload

1. Validação de formato de arquivo
2. Validação de tamanho máximo (50 MB)
3. Geração de nome único (UUID + extensão)
4. Upload para MinIO
5. Extração de coordenadas EXIF
6. Salvamento de metadados no banco
7. Geração de URL pública
8. Retorno de sucesso ou erro por arquivo

## Códigos HTTP

- `201 Created` - Todos os uploads bem-sucedidos
- `207 Multi-Status` - Alguns arquivos sucesso, outros falharam
- `400 Bad Request` - Todos os arquivos falharam

## Tecnologias Utilizadas

- FastAPI
- MinIO (S3 compatível)
- Pillow (extração EXIF)
- Docker Compose (orquestração)
- Python 3.13

## Validações Implementadas

- ✅ Formato: JPG, PNG, TIFF
- ✅ Tamanho: 50 MB máximo
- ✅ Arquivo vazio
- ✅ Geolocalização (com fallback)
- ✅ Configuração automática do bucket público


## Extras

- Script `setup-minio.sh` para configurar bucket público automaticamente
- Container `minio_setup` que roda após inicialização do MinIO
- Validações permitem projeto funcionar offline (com bucket público)
- URLs sem presigned tokens para facilitar desenvolvimento/testes
- Fallback para coordenadas (0.0, 0.0) permite aceitar fotos sem geolocalização